### PR TITLE
Rename project to meditation mini program and backend

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.dromara</groupId>
-    <artifactId>ruoyi-vue-plus</artifactId>
+    <artifactId>meditation-admin</artifactId>
     <version>${revision}</version>
 
-    <name>RuoYi-Vue-Plus</name>
-    <url>https://gitee.com/dromara/RuoYi-Vue-Plus</url>
-    <description>Dromara RuoYi-Vue-Plus多租户管理系统</description>
+    <name>冥想后台管理</name>
+    <url>https://github.com/meditation-admin</url>
+    <description>冥想后台管理系统</description>
 
     <properties>
         <revision>5.4.1</revision>
@@ -67,7 +67,7 @@
                 <!-- 环境标识，需要与配置文件的名称相对应 -->
                 <profiles.active>local</profiles.active>
                 <logging.level>info</logging.level>
-                <monitor.username>ruoyi</monitor.username>
+                <monitor.username>meditation</monitor.username>
                 <monitor.password>123456</monitor.password>
             </properties>
         </profile>
@@ -77,7 +77,7 @@
                 <!-- 环境标识，需要与配置文件的名称相对应 -->
                 <profiles.active>dev</profiles.active>
                 <logging.level>info</logging.level>
-                <monitor.username>ruoyi</monitor.username>
+                <monitor.username>meditation</monitor.username>
                 <monitor.password>123456</monitor.password>
             </properties>
             <activation>
@@ -90,7 +90,7 @@
             <properties>
                 <profiles.active>prod</profiles.active>
                 <logging.level>warn</logging.level>
-                <monitor.username>ruoyi</monitor.username>
+                <monitor.username>meditation</monitor.username>
                 <monitor.password>123456</monitor.password>
             </properties>
         </profile>

--- a/ruoyi-admin/src/main/resources/application.yml
+++ b/ruoyi-admin/src/main/resources/application.yml
@@ -52,7 +52,7 @@ user:
 # Spring配置
 spring:
   application:
-    name: RuoYi-Vue-Plus
+    name: 冥想后台管理
   threads:
     # 开启虚拟线程 仅jdk21可用
     virtual:

--- a/ruoyi-extend/ruoyi-monitor-admin/src/main/resources/application.yml
+++ b/ruoyi-extend/ruoyi-monitor-admin/src/main/resources/application.yml
@@ -2,7 +2,7 @@ server:
   port: 9090
 spring:
   application:
-    name: ruoyi-monitor-admin
+    name: 冥想监控管理
   profiles:
     active: @profiles.active@
 
@@ -18,7 +18,7 @@ spring:
   boot:
     admin:
       ui:
-        title: RuoYi-Vue-Plus服务监控中心
+        title: 冥想后台服务监控中心
       context-path: /admin
 
 --- # Actuator 监控端点的配置项
@@ -31,7 +31,7 @@ management:
     health:
       show-details: ALWAYS
     logfile:
-      external-file: ./logs/ruoyi-monitor-admin.log
+      external-file: ./logs/meditation-monitor-admin.log
 
 --- # 监控配置
 spring.boot.admin.client:


### PR DESCRIPTION
Rename backend project identifiers and names from "RuoYi-Vue-Plus" to "冥想后台管理" (Meditation Admin Management) to align with new branding.

---
<a href="https://cursor.com/background-agent?bcId=bc-e634d3f2-bedc-4e3a-a1ca-65039a278f9a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e634d3f2-bedc-4e3a-a1ca-65039a278f9a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

