### PR TITLE
Integrate category page meditations and record playback

### DIFF
--- a/PLAY_HISTORY_INTEGRATION.md
+++ b/PLAY_HISTORY_INTEGRATION.md
@@ -1,0 +1,180 @@
+# 播放历史记录功能集成文档
+
+## 概述
+本次更新实现了小程序分类页面的全部冥想展示功能，并完善了播放历史记录功能。
+
+## 主要更新内容
+
+### 1. 后端更新
+
+#### 1.1 新增获取所有冥想单集接口
+- **文件**: `/workspace/ruoyi-modules/ruoyi-meditation/src/main/java/org/dromara/meditation/controller/TrackController.java`
+- **新增接口**: `GET /meditation/track/all`
+- **功能**: 获取所有冥想单集，不分页
+```java
+@SaIgnore
+@GetMapping("/all")
+public R<List<TrackVo>> getAllTracks(TrackBo bo) {
+    return R.ok(trackService.queryList(bo));
+}
+```
+
+#### 1.2 播放历史自动记录用户ID
+- **文件**: `/workspace/ruoyi-modules/ruoyi-meditation/src/main/java/org/dromara/meditation/service/impl/PlayHistoryServiceImpl.java`
+- **更新内容**: 在`validEntityBeforeSave`方法中自动设置当前登录用户的ID
+```java
+private void validEntityBeforeSave(PlayHistory entity){
+    // 自动设置当前用户ID
+    if (entity.getUserId() == null) {
+        try {
+            Long userId = LoginHelper.getUserId();
+            entity.setUserId(userId);
+        } catch (Exception e) {
+            log.warn("获取当前用户ID失败，可能是未登录状态: {}", e.getMessage());
+        }
+    }
+}
+```
+
+### 2. 前端更新
+
+#### 2.1 分类页面全部冥想加载
+- **文件**: `/workspace/meditation-uniapp/pages/category/index.vue`
+- **更新内容**:
+  - 修改`loadTracksList`方法，一次性加载所有冥想单集
+  - 使用新的`getAllTracks` API
+  - 移除单集的分页加载逻辑
+  - 更新加载更多按钮，只显示系列的加载更多
+
+#### 2.2 新增API方法
+- **文件**: `/workspace/meditation-uniapp/api/track.js`
+- **新增方法**: `getAllTracks`
+```javascript
+export const getAllTracks = (params) => get('/meditation/track/all', params)
+```
+
+#### 2.3 播放器页面播放历史记录优化
+- **文件**: `/workspace/meditation-uniapp/pages/player/index.vue`
+- **更新内容**:
+  - 添加Vuex mapGetters获取用户信息
+  - 在创建播放历史时包含userId
+  - 在更新播放进度时包含userId
+  - 在标记完成时包含userId
+  - 添加日志输出，便于调试
+
+## 功能特点
+
+### 1. 全部冥想展示
+- 分类页面现在一次性加载该分类下的所有冥想单集
+- 避免了用户需要多次点击"加载更多"的问题
+- 提升了用户体验
+
+### 2. 播放历史记录
+- **自动记录**: 当用户开始播放音频时，自动创建播放历史记录
+- **进度跟踪**: 每10秒自动更新播放进度
+- **完成标记**: 当播放进度达到95%以上时，自动标记为已完成
+- **用户关联**: 播放历史与当前登录用户自动关联
+
+### 3. 数据结构
+播放历史记录包含以下信息：
+- `userId`: 用户ID（自动获取）
+- `trackId`: 音频单集ID
+- `progressSec`: 播放进度（秒）
+- `isCompleted`: 是否完成（'0'未完成，'1'已完成）
+- `createTime`: 创建时间
+- `updateTime`: 更新时间
+
+## API接口说明
+
+### 1. 获取所有冥想单集
+```
+GET /meditation/track/all
+参数：
+- categoryId: 分类ID（可选）
+- status: 状态（0-正常）
+```
+
+### 2. 创建播放历史
+```
+POST /meditation/playHistory
+请求体：
+{
+  "trackId": 1,
+  "progressSec": 0,
+  "isCompleted": "0"
+}
+```
+
+### 3. 更新播放进度
+```
+PUT /meditation/playHistory
+请求体：
+{
+  "id": 1,
+  "trackId": 1,
+  "progressSec": 120,
+  "isCompleted": "0"
+}
+```
+
+### 4. 获取播放历史列表
+```
+GET /meditation/playHistory/list
+参数：
+- pageNum: 页码
+- pageSize: 每页大小
+```
+
+### 5. 获取播放历史详情列表（包含单集信息）
+```
+GET /meditation/playHistory/detail/list
+参数：
+- pageNum: 页码
+- pageSize: 每页大小
+```
+
+## 测试方法
+
+1. **启动后端服务**
+```bash
+cd /workspace
+mvn spring-boot:run
+```
+
+2. **启动小程序**
+```bash
+cd /workspace/meditation-uniapp
+npm run dev:mp-weixin
+```
+
+3. **测试流程**
+   - 登录小程序
+   - 进入分类页面，查看是否加载了所有冥想
+   - 点击任意冥想进入播放页面
+   - 播放音频，检查控制台日志是否显示"播放历史记录成功"
+   - 暂停/继续播放，检查进度是否更新
+   - 播放完成后，检查是否标记为已完成
+
+4. **使用测试脚本**
+```bash
+# 编辑脚本，填入有效的TOKEN
+vi /workspace/test_play_history.sh
+
+# 运行测试
+./test_play_history.sh
+```
+
+## 注意事项
+
+1. **用户登录**: 播放历史记录需要用户登录后才能正常记录
+2. **权限控制**: 部分接口使用了`@SaIgnore`注解，允许未登录访问
+3. **数据安全**: 用户只能查看自己的播放历史
+4. **性能优化**: 全部冥想加载可能会影响性能，建议后续考虑虚拟滚动等优化方案
+
+## 后续优化建议
+
+1. **虚拟滚动**: 当冥想数量较多时，实现虚拟滚动以提升性能
+2. **缓存机制**: 添加本地缓存，减少重复请求
+3. **离线播放**: 支持离线播放历史记录同步
+4. **统计分析**: 基于播放历史提供用户行为分析
+5. **推荐系统**: 根据播放历史推荐相关内容

--- a/meditation-uniapp/api/track.js
+++ b/meditation-uniapp/api/track.js
@@ -2,6 +2,7 @@ import { get, post } from '@/utils/request'
 
 // 冥想单集
 export const listTracks = (params) => get('/meditation/track/list', params)
+export const getAllTracks = (params) => get('/meditation/track/all', params)
 export const getTrack = (id) => get(`/meditation/track/${id}`)
 export const getTrackDetail = (id) => get(`/meditation/track/${id}`)
 
@@ -9,7 +10,8 @@ export const getTrackDetail = (id) => get(`/meditation/track/${id}`)
 export const recordPlay = (trackId) => post('/meditation/playHistory', { trackId })
 
 export default { 
-  listTracks, 
+  listTracks,
+  getAllTracks, 
   getTrack,
   getTrackDetail,
   recordPlay

--- a/meditation-uniapp/pages/category/index.vue
+++ b/meditation-uniapp/pages/category/index.vue
@@ -66,10 +66,10 @@
       </view>
     </view>
 
-    <!-- 加载更多 -->
-    <view class="load-more" v-if="hasMore" @click="loadMore">
+    <!-- 加载更多 - 全部冥想不需要加载更多按钮 -->
+    <view class="load-more" v-if="seriesHasMore" @click="loadSeriesList">
       <tn-icon name="more" size="16" color="#666"></tn-icon>
-      <text class="load-text">加载更多</text>
+      <text class="load-text">加载更多系列</text>
     </view>
 
     <!-- 空状态 -->
@@ -83,7 +83,7 @@
 <script>
 import { listCategories } from '@/api/category'
 import { listSeries } from '@/api/series'
-import { listTracks } from '@/api/track'
+import { listTracks, getAllTracks } from '@/api/track'
 
 export default {
   data() {
@@ -156,27 +156,26 @@ export default {
       }
     },
 
-    // 加载单集列表
+    // 加载单集列表 - 修改为加载全部冥想
     async loadTracksList(reset = false) {
       if (reset) {
         this.tracksPageNum = 1;
         this.tracks = [];
-        this.tracksHasMore = true
+        this.tracksHasMore = false  // 改为不分页，一次加载全部
       }
-      if (!this.tracksHasMore || this.loading) return
+      if (this.loading) return
 
       this.loading = true
       try {
-        const res = await listTracks({
+        // 使用新的getAllTracks API一次性加载所有冥想单集
+        const res = await getAllTracks({
           categoryId: this.currentCategoryId,
-          status: 0,
-          pageNum: this.tracksPageNum,
-          pageSize: 10
+          status: 0
         })
-        const rows = res.rows || res.data || []
-        this.tracks = this.tracks.concat(rows)
-        this.tracksHasMore = rows.length >= 10
-        if (this.tracksHasMore) this.tracksPageNum += 1
+        const rows = res.data || []
+        this.tracks = rows  // 直接设置所有数据
+        this.tracksHasMore = false  // 不再有更多数据
+        console.log(`加载了 ${rows.length} 个冥想单集`)
       } catch (error) {
         console.error('加载单集列表失败:', error)
         uni.showToast({
@@ -254,19 +253,16 @@ export default {
     }
   },
   onReachBottom() {
-    // 根据滚动位置决定加载哪个模块的数据
-    // 这里简单处理，优先加载系列数据
+    // 只需要加载更多系列数据，单集已经全部加载
     if (this.seriesHasMore) {
       this.loadSeriesList()
-    } else if (this.tracksHasMore) {
-      this.loadTracksList()
     }
   },
 
   onPullDownRefresh() {
     // 刷新时重新加载所有数据
     this.loadSeriesList(true)
-    this.loadTracksList(true)
+    this.loadTracksList(true)  // 重新加载全部冥想
     uni.stopPullDownRefresh()
   }
 }

--- a/meditation-uniapp/pages/player/index.vue
+++ b/meditation-uniapp/pages/player/index.vue
@@ -193,8 +193,12 @@
 import { getTrackDetail, recordPlay } from '@/api/track'
 import { addFavorite, removeFavorite, checkFavorite } from '@/api/favorite'
 import { addPlayHistory, updatePlayHistory } from '@/api/play'
+import { mapGetters } from 'vuex'
 
 export default {
+  computed: {
+    ...mapGetters(['userInfo'])
+  },
   data() {
     return {
       trackId: '',
@@ -359,14 +363,25 @@ export default {
     // 添加到播放历史
     async addToPlayHistory() {
       try {
-        const res = await addPlayHistory({
+        // 获取当前用户ID
+        const userId = this.userInfo?.userId || this.userInfo?.id
+        
+        const playHistoryData = {
           trackId: this.trackId,
           progressSec: Math.floor(this.currentTime),
           isCompleted: '0'
-        })
+        }
+        
+        // 如果有用户ID，添加到请求数据中
+        if (userId) {
+          playHistoryData.userId = userId
+        }
+        
+        const res = await addPlayHistory(playHistoryData)
         
         if (res.code === 200 && res.data) {
           this.playHistoryId = res.data.id
+          console.log('播放历史记录成功, ID:', this.playHistoryId)
         }
       } catch (error) {
         console.error('添加播放历史失败:', error)
@@ -399,12 +414,23 @@ export default {
         const progressSec = Math.floor(this.currentTime)
         const isCompleted = this.duration > 0 && this.currentTime >= this.duration * 0.95 ? '1' : '0'
         
-        await updatePlayHistory({
+        // 获取当前用户ID
+        const userId = this.userInfo?.userId || this.userInfo?.id
+        
+        const updateData = {
           id: this.playHistoryId,
           trackId: this.trackId,
           progressSec: progressSec,
           isCompleted: isCompleted
-        })
+        }
+        
+        // 如果有用户ID，添加到更新数据中
+        if (userId) {
+          updateData.userId = userId
+        }
+        
+        await updatePlayHistory(updateData)
+        console.log('播放进度已更新:', progressSec, '秒, 完成状态:', isCompleted)
       } catch (error) {
         console.error('更新播放进度失败:', error)
       }
@@ -415,12 +441,23 @@ export default {
       if (!this.playHistoryId || !this.trackId) return
       
       try {
-        await updatePlayHistory({
+        // 获取当前用户ID
+        const userId = this.userInfo?.userId || this.userInfo?.id
+        
+        const updateData = {
           id: this.playHistoryId,
           trackId: this.trackId,
           progressSec: Math.floor(this.duration),
           isCompleted: '1'
-        })
+        }
+        
+        // 如果有用户ID，添加到更新数据中
+        if (userId) {
+          updateData.userId = userId
+        }
+        
+        await updatePlayHistory(updateData)
+        console.log('播放完成，已标记')
       } catch (error) {
         console.error('标记完成失败:', error)
       }

--- a/ruoyi-modules/ruoyi-meditation/src/main/java/org/dromara/meditation/controller/TrackController.java
+++ b/ruoyi-modules/ruoyi-meditation/src/main/java/org/dromara/meditation/controller/TrackController.java
@@ -47,6 +47,15 @@ public class TrackController extends BaseController {
     }
 
     /**
+     * 获取所有冥想单集（不分页）
+     */
+    @SaIgnore
+    @GetMapping("/all")
+    public R<List<TrackVo>> getAllTracks(TrackBo bo) {
+        return R.ok(trackService.queryList(bo));
+    }
+
+    /**
      * 导出冥想单集列表
      */
     @SaCheckPermission("meditation:track:export")

--- a/ruoyi-modules/ruoyi-meditation/src/main/java/org/dromara/meditation/service/impl/PlayHistoryServiceImpl.java
+++ b/ruoyi-modules/ruoyi-meditation/src/main/java/org/dromara/meditation/service/impl/PlayHistoryServiceImpl.java
@@ -148,6 +148,15 @@ public class PlayHistoryServiceImpl implements IPlayHistoryService {
      * 保存前的数据校验
      */
     private void validEntityBeforeSave(PlayHistory entity){
+        // 自动设置当前用户ID
+        if (entity.getUserId() == null) {
+            try {
+                Long userId = LoginHelper.getUserId();
+                entity.setUserId(userId);
+            } catch (Exception e) {
+                log.warn("获取当前用户ID失败，可能是未登录状态: {}", e.getMessage());
+            }
+        }
         //TODO 做一些数据校验,如唯一约束
     }
 

--- a/test_play_history.sh
+++ b/test_play_history.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# 测试播放历史记录功能
+echo "========================================="
+echo "测试播放历史记录功能"
+echo "========================================="
+
+# 设置基础URL
+BASE_URL="http://localhost:8080"
+API_PREFIX="/meditation"
+
+# 测试用的token（需要先登录获取）
+TOKEN=""
+
+echo "1. 测试获取所有冥想单集（不分页）"
+echo "-----------------------------------------"
+curl -X GET "${BASE_URL}${API_PREFIX}/track/all?status=0" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${TOKEN}"
+
+echo -e "\n\n2. 测试创建播放历史记录"
+echo "-----------------------------------------"
+# 创建播放历史（trackId需要根据实际数据调整）
+curl -X POST "${BASE_URL}${API_PREFIX}/playHistory" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -d '{
+    "trackId": 1,
+    "progressSec": 0,
+    "isCompleted": "0"
+  }'
+
+echo -e "\n\n3. 测试更新播放进度"
+echo "-----------------------------------------"
+# 更新播放进度（id需要根据创建返回的ID调整）
+curl -X PUT "${BASE_URL}${API_PREFIX}/playHistory" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -d '{
+    "id": 1,
+    "trackId": 1,
+    "progressSec": 120,
+    "isCompleted": "0"
+  }'
+
+echo -e "\n\n4. 测试标记播放完成"
+echo "-----------------------------------------"
+# 标记为已完成
+curl -X PUT "${BASE_URL}${API_PREFIX}/playHistory" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -d '{
+    "id": 1,
+    "trackId": 1,
+    "progressSec": 600,
+    "isCompleted": "1"
+  }'
+
+echo -e "\n\n5. 测试获取播放历史列表"
+echo "-----------------------------------------"
+curl -X GET "${BASE_URL}${API_PREFIX}/playHistory/list?pageNum=1&pageSize=10" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${TOKEN}"
+
+echo -e "\n\n测试完成！"
+echo "========================================="


### PR DESCRIPTION
Integrate all meditations on the category page and enhance playback history recording with user association.

The user requested that the `/pages/category/index` page display all meditations without pagination and that all playback actions (start, progress update, completion) be recorded in the backend, automatically associating with the logged-in user. This PR implements these features by adding a new backend API for all tracks, updating the frontend to use it, and enhancing play history recording to include user IDs automatically.

---
<a href="https://cursor.com/background-agent?bcId=bc-44a803c4-410f-4f2d-9297-161cfcc0e767">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-44a803c4-410f-4f2d-9297-161cfcc0e767">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

