### PR TITLE
Display URLs instead of IDs in list

### DIFF
--- a/meditation-web-ts/src/api/meditation/article/types.ts
+++ b/meditation-web-ts/src/api/meditation/article/types.ts
@@ -17,6 +17,11 @@ export interface ArticleVO {
   cover: string;
 
   /**
+   * 封面文件URL
+   */
+  coverUrl?: string;
+
+  /**
    * 摘要
    */
   summary: string;

--- a/meditation-web-ts/src/api/meditation/series/types.ts
+++ b/meditation-web-ts/src/api/meditation/series/types.ts
@@ -27,9 +27,19 @@ export interface SeriesVO {
   cover: string;
 
   /**
+   * 封面文件URL
+   */
+  coverUrl?: string;
+
+  /**
    * 横幅图文件id（sys_oss.oss_id）
    */
   banner: string;
+
+  /**
+   * 横幅图文件URL
+   */
+  bannerUrl?: string;
 
   /**
    * 简介

--- a/meditation-web-ts/src/api/meditation/track/types.ts
+++ b/meditation-web-ts/src/api/meditation/track/types.ts
@@ -25,9 +25,19 @@ export interface TrackVO {
   cover: string;
 
   /**
+   * 封面文件URL
+   */
+  coverUrl?: string;
+
+  /**
    * 音频文件id（sys_oss.oss_id）
    */
   audio: string;
+
+  /**
+   * 音频文件URL
+   */
+  audioUrl?: string;
 
   /**
    * 时长（秒）

--- a/meditation-web-ts/src/views/meditation/article/index.vue
+++ b/meditation-web-ts/src/views/meditation/article/index.vue
@@ -69,9 +69,9 @@
         <el-table-column type="selection" width="55" align="center" />
         <el-table-column label="主键" align="center" prop="id" v-if="false" />
         <el-table-column label="标题" align="center" prop="title" />
-        <el-table-column label="封面" align="center" prop="cover">
+        <el-table-column label="封面" align="center" prop="coverUrl">
           <template #default="scope">
-            <image-preview :src="scope.row.cover" :width="50" :height="50"/>
+            <image-preview :src="scope.row.coverUrl" :width="50" :height="50"/>
           </template>
         </el-table-column>
         <el-table-column label="摘要" align="center" prop="summary" :show-overflow-tooltip="true" />

--- a/meditation-web-ts/src/views/meditation/series/index.vue
+++ b/meditation-web-ts/src/views/meditation/series/index.vue
@@ -72,9 +72,9 @@
         </el-table-column>
         <el-table-column label="标题" align="center" prop="title" />
         <el-table-column label="副标题" align="center" prop="subtitle" />
-        <el-table-column label="封面" align="center" prop="cover">
+        <el-table-column label="封面" align="center" prop="coverUrl">
           <template #default="scope">
-            <image-preview :src="scope.row.cover" :width="50" :height="50"/>
+            <image-preview :src="scope.row.coverUrl" :width="50" :height="50"/>
           </template>
         </el-table-column>
         <el-table-column label="简介" align="center" prop="intro" :show-overflow-tooltip="true" />

--- a/meditation-web-ts/src/views/meditation/track/index.vue
+++ b/meditation-web-ts/src/views/meditation/track/index.vue
@@ -69,9 +69,9 @@
           </template>
         </el-table-column>
         <el-table-column label="标题" align="center" prop="title" />
-        <el-table-column label="封面" align="center" prop="cover">
+        <el-table-column label="封面" align="center" prop="coverUrl">
           <template #default="scope">
-            <image-preview :src="scope.row.cover" :width="50" :height="50"/>
+            <image-preview :src="scope.row.coverUrl" :width="50" :height="50"/>
           </template>
         </el-table-column>
         <el-table-column label="时长" align="center" prop="durationSec" />

--- a/test_image_urls.md
+++ b/test_image_urls.md
@@ -1,0 +1,70 @@
+# 图片URL显示测试说明
+
+## 修改内容总结
+
+我已经完成了以下修改，将列表展示图片时从显示ID改为显示URL：
+
+### 后端修改
+
+1. **SeriesVo.java** - 已包含 `coverUrl` 和 `bannerUrl` 字段，使用 `@Translation` 注解自动转换OSS ID到URL
+2. **TrackVo.java** - 已包含 `coverUrl` 和 `audioUrl` 字段，使用 `@Translation` 注解自动转换OSS ID到URL  
+3. **BannerVo.java** - 已包含 `imageUrl` 字段，使用 `@Translation` 注解自动转换OSS ID到URL
+4. **ArticleVo.java** - 已包含 `coverUrl` 字段，使用 `@Translation` 注解自动转换OSS ID到URL
+5. **CategoryVo.java** - `icon` 字段直接使用 `@Translation` 注解转换为URL
+
+### 前端修改
+
+1. **series/index.vue** - 修改表格列从 `cover` 改为 `coverUrl`
+2. **track/index.vue** - 修改表格列从 `cover` 改为 `coverUrl`  
+3. **article/index.vue** - 修改表格列从 `cover` 改为 `coverUrl`
+4. **banner/index.vue** - 已经使用 `imageUrl` (无需修改)
+5. **category/index.vue** - 已经使用 `icon` (无需修改)
+
+### TypeScript类型定义更新
+
+1. **series/types.ts** - 添加 `coverUrl` 和 `bannerUrl` 可选字段
+2. **track/types.ts** - 添加 `coverUrl` 和 `audioUrl` 可选字段
+3. **article/types.ts** - 添加 `coverUrl` 可选字段
+
+## 测试步骤
+
+1. 启动后端服务：
+   ```bash
+   cd /workspace
+   mvn spring-boot:run -pl ruoyi-admin -Dspring-boot.run.profiles=dev
+   ```
+
+2. 启动前端服务：
+   ```bash
+   cd /workspace/meditation-web-ts
+   npm run dev
+   ```
+
+3. 访问系统并测试以下页面：
+   - 冥想系列管理 - 查看封面图片是否正常显示URL
+   - 冥想单集管理 - 查看封面图片是否正常显示URL
+   - 冥想文章管理 - 查看封面图片是否正常显示URL
+   - 横幅配置管理 - 查看图片是否正常显示URL
+   - 分类管理 - 查看图标是否正常显示URL
+
+## 工作原理
+
+后端使用了 `@Translation` 注解，这是一个自动翻译注解，会在返回数据时自动将OSS ID转换为对应的URL。例如：
+
+```java
+@Translation(type = TransConstant.OSS_ID_TO_URL, mapper = "cover")
+private String coverUrl;
+```
+
+这个注解会：
+1. 读取 `cover` 字段的值（OSS ID）
+2. 通过OSS服务查询对应的URL
+3. 将URL设置到 `coverUrl` 字段
+
+前端只需要使用 `coverUrl` 字段即可直接获取到图片的URL，而不是OSS ID。
+
+## 注意事项
+
+- 确保后端的OSS服务配置正确，能够正常查询OSS ID对应的URL
+- 如果图片仍显示ID而不是URL，请检查后端日志确认 `@Translation` 注解是否正常工作
+- 新增的URL字段都是可选的（`?`），以保持向后兼容性


### PR DESCRIPTION
Update frontend list views to display image URLs instead of OSS IDs for better user experience.

The backend already provides translated URL fields (e.g., `coverUrl`, `bannerUrl`) via `@Translation` annotations. This PR updates the frontend components and TypeScript types to consume these URL fields, ensuring images are displayed directly rather than their internal ID references in list views.

---
<a href="https://cursor.com/background-agent?bcId=bc-884276a2-bc58-4764-af1f-411117672b6d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-884276a2-bc58-4764-af1f-411117672b6d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

