### PR TITLE
Fix player data loading from homepage

### DIFF
--- a/meditation-uniapp/components/MiniPlayer/index.vue
+++ b/meditation-uniapp/components/MiniPlayer/index.vue
@@ -1,33 +1,31 @@
 <template>
-  <view class="mini-player" v-if="showPlayer" @click="goToPlayer">
-    <view class="player-content">
-      <!-- 封面图 -->
-      <image 
-        class="cover-image" 
-        :src="(currentTrack && currentTrack.coverUrl) || '/static/images/default-cover.png'" 
-        mode="aspectFill"
-      />
-      
-      <!-- 歌曲信息 -->
+  <view class="mini-player" v-if="showPlayer">
+    <!-- 圆形封面 -->
+    <image 
+      class="cover-circle" 
+      :src="(currentTrack && currentTrack.coverUrl) || '/static/images/default-cover.png'" 
+      mode="aspectFill"
+      @click="goToPlayer"
+    />
+    
+    <!-- 长方形播放条 -->
+    <view class="player-bar" @click="goToPlayer">
+      <!-- 音乐信息 -->
       <view class="track-info">
         <text class="track-title">{{ (currentTrack && currentTrack.title) || '未知音频' }}</text>
+        <!-- 定时器信息 -->
         <view class="timer-info" v-if="sleepTimerRemaining">
           <image class="timer-icon" src="/static/player/time-icon.png" />
-          <text class="timer-text">定时停止 {{ formatTimerRemaining }}</text>
+          <text class="timer-text">{{ formatTimerRemaining }}</text>
         </view>
       </view>
       
-      <!-- 播放控制 -->
-      <view class="controls">
-        <view class="control-btn" @click.stop="togglePlay">
-          <image 
-            class="play-icon" 
-            :src="isPlaying ? '/static/player/close-pause-icon.png' : '/static/player/play-pause-icon.png'" 
-          />
-        </view>
-        <view class="control-btn" @click.stop="closePlayer">
-          <image class="close-icon" src="/static/player/close.png" />
-        </view>
+      <!-- 播放/暂停按钮 -->
+      <view class="play-btn" @click.stop="togglePlay">
+        <image 
+          class="play-icon" 
+          :src="isPlaying ? '/static/player/close-pause-icon.png' : '/static/player/play-pause-icon.png'" 
+        />
       </view>
     </view>
   </view>
@@ -278,15 +276,6 @@ export default {
       }
     },
     
-    // 关闭播放器
-    closePlayer() {
-      if (this.audioContext) {
-        this.audioContext.stop()
-        this.currentTrack = null
-        this.isPlaying = false
-      }
-    },
-    
     // 跳转到播放器页面
     goToPlayer() {
       // 获取当前播放的音轨ID（可能需要从存储中获取）
@@ -306,14 +295,11 @@ export default {
 .mini-player {
   position: fixed;
   bottom: 100rpx;
-  left: 20rpx;
-  right: 20rpx;
-  height: 120rpx;
-  background: rgba(255, 255, 255, 0.95);
-  border-radius: 20rpx;
-  box-shadow: 0 4rpx 20rpx rgba(0, 0, 0, 0.15);
+  left: 24rpx;
+  right: 24rpx;
+  display: flex;
+  align-items: center;
   z-index: 999;
-  backdrop-filter: blur(10px);
   animation: slideUp 0.3s ease-out;
 }
 
@@ -328,38 +314,53 @@ export default {
   }
 }
 
-.player-content {
+// 圆形封面
+.cover-circle {
+  width: 112rpx;
+  height: 112rpx;
+  border-radius: 50%;
+  flex-shrink: 0;
+  box-shadow: 0 4rpx 12rpx rgba(0, 0, 0, 0.15);
+  background: #fff;
+  z-index: 2;
+  position: relative;
+}
+
+// 长方形播放条
+.player-bar {
+  flex: 1;
+  height: 96rpx;
+  background: #6D8BA1;
+  border-radius: 52rpx;
+  opacity: 0.9;
+  backdrop-filter: blur(3px);
   display: flex;
   align-items: center;
-  height: 100%;
-  padding: 15rpx;
+  padding: 0 30rpx 0 70rpx; // 左边留出空间给圆形封面
+  margin-left: -56rpx; // 让长方形与圆形拼接
+  position: relative;
 }
 
-.cover-image {
-  width: 90rpx;
-  height: 90rpx;
-  border-radius: 12rpx;
-  flex-shrink: 0;
-}
-
+// 音乐信息
 .track-info {
   flex: 1;
-  margin: 0 20rpx;
   display: flex;
   flex-direction: column;
   justify-content: center;
+  gap: 8rpx;
 }
 
 .track-title {
-  font-size: 28rpx;
-  color: #333;
+  font-size: 30rpx;
+  color: #FFFFFF;
   font-weight: 500;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  margin-bottom: 8rpx;
+  max-width: 400rpx;
 }
 
+// 定时器信息
 .timer-info {
   display: flex;
   align-items: center;
@@ -369,42 +370,33 @@ export default {
 .timer-icon {
   width: 24rpx;
   height: 24rpx;
+  opacity: 0.8;
 }
 
 .timer-text {
-  font-size: 22rpx;
-  color: #7B9FD4;
+  font-size: 24rpx;
+  color: rgba(255, 255, 255, 0.8);
 }
 
-.controls {
-  display: flex;
-  align-items: center;
-  gap: 20rpx;
-}
-
-.control-btn {
+// 播放按钮
+.play-btn {
   width: 60rpx;
   height: 60rpx;
   display: flex;
   align-items: center;
   justify-content: center;
   border-radius: 50%;
-  background: rgba(123, 159, 212, 0.1);
+  background: rgba(255, 255, 255, 0.2);
   transition: all 0.2s;
   
   &:active {
     transform: scale(0.9);
-    background: rgba(123, 159, 212, 0.2);
+    background: rgba(255, 255, 255, 0.3);
   }
 }
 
 .play-icon {
-  width: 48rpx;
-  height: 48rpx;
-}
-
-.close-icon {
-  width: 28rpx;
-  height: 28rpx;
+  width: 36rpx;
+  height: 36rpx;
 }
 </style>

--- a/meditation-uniapp/pages/category/index.vue
+++ b/meditation-uniapp/pages/category/index.vue
@@ -320,8 +320,9 @@ export default {
 
     // 播放系列
     playSeries(series) {
+      // 直接跳转到播放器，播放系列的第一个音频
       uni.navigateTo({
-        url: `/pages/series/detail?id=${series.id}`
+        url: `/pages/player/index?seriesId=${series.id}&type=series`
       })
     },
 

--- a/meditation-uniapp/pages/favorites/index.vue
+++ b/meditation-uniapp/pages/favorites/index.vue
@@ -288,15 +288,9 @@ export default {
         return
       }
       
-      // 获取所有音频类型的收藏
-      const audioFavorites = this.favoritesList.filter(fav => fav.targetType === 'track')
-      
-      // 准备列表数据
-      const listData = encodeURIComponent(JSON.stringify(audioFavorites))
-      
-      // 跳转到播放器页面，传递收藏列表
+      // 跳转到播放器页面
       uni.navigateTo({
-        url: `/pages/player/index?id=${item.targetId}&source=favorites&list=${listData}`
+        url: `/pages/player/index?id=${item.targetId}&source=favorites`
       })
     },
     

--- a/meditation-uniapp/pages/favorites/index.vue
+++ b/meditation-uniapp/pages/favorites/index.vue
@@ -133,7 +133,7 @@ export default {
   methods: {
     // 初始化背景音频管理器
     initBackgroundAudio() {
-      // #ifdef MP-WEIXIN || MP-BAIDU || MP-QQ
+      // 统一使用全局唯一的背景音频管理器
       this.backgroundAudioManager = uni.getBackgroundAudioManager()
       
       this.backgroundAudioManager.onPlay(() => {
@@ -165,19 +165,12 @@ export default {
         })
         this.isPlaying = false
       })
-      // #endif
-      
-      // #ifndef MP-WEIXIN || MP-BAIDU || MP-QQ
-      this.backgroundAudioManager = uni.createInnerAudioContext()
-      // #endif
     },
     
     // 检查当前播放状态
     checkPlayingStatus() {
       if (this.backgroundAudioManager) {
-        // #ifdef MP-WEIXIN || MP-BAIDU || MP-QQ
         this.isPlaying = !this.backgroundAudioManager.paused
-        // #endif
       }
     },
     
@@ -308,20 +301,17 @@ export default {
       // 播放新的音频
       this.currentPlaying = item
       
-      // #ifdef MP-WEIXIN || MP-BAIDU || MP-QQ
-      // 小程序使用背景音频管理器
-      this.backgroundAudioManager.title = item.title
+      // 统一使用背景音频管理器播放
+      this.backgroundAudioManager.title = item.title || '未知音频'
       this.backgroundAudioManager.singer = item.subtitle || '冥想音乐'
-      this.backgroundAudioManager.coverImgUrl = item.cover
-      this.backgroundAudioManager.src = item.audioUrl
-      // #endif
+      this.backgroundAudioManager.coverImgUrl = item.cover || '/static/images/default-cover.jpg'
+      this.backgroundAudioManager.epname = item.title || '冥想音频'
       
-      // #ifndef MP-WEIXIN || MP-BAIDU || MP-QQ
-      // 非小程序环境跳转到播放页面
-      uni.navigateTo({
-        url: `/pages/player/index?id=${item.targetId}&title=${encodeURIComponent(item.title)}`
-      })
-      // #endif
+      // 设置音频源，这会自动开始播放
+      this.backgroundAudioManager.src = item.audioUrl
+      
+      // 保存当前播放的音轨ID，供迷你播放器使用
+      uni.setStorageSync('currentTrackId', item.targetId)
     },
     
     // 暂停音频

--- a/meditation-uniapp/pages/favorites/index.vue
+++ b/meditation-uniapp/pages/favorites/index.vue
@@ -275,9 +275,9 @@ export default {
       // 只处理音频类型
       if (item.targetType !== 'track') {
         if (item.targetType === 'series') {
-          // 跳转到系列详情页
+          // 系列类型，跳转到播放器播放系列
           uni.navigateTo({
-            url: `/pages/series/detail?id=${item.targetId}`
+            url: `/pages/player/index?seriesId=${item.targetId}&type=series`
           })
         } else if (item.targetType === 'article') {
           // 跳转到文章详情页
@@ -288,30 +288,16 @@ export default {
         return
       }
       
-      // 如果点击的是当前正在播放的音频
-      if (this.currentPlaying && this.currentPlaying.targetId === item.targetId) {
-        if (this.isPlaying) {
-          this.pauseAudio()
-        } else {
-          this.resumeAudio()
-        }
-        return
-      }
+      // 获取所有音频类型的收藏
+      const audioFavorites = this.favoritesList.filter(fav => fav.targetType === 'track')
       
-      // 播放新的音频
-      this.currentPlaying = item
+      // 准备列表数据
+      const listData = encodeURIComponent(JSON.stringify(audioFavorites))
       
-      // 统一使用背景音频管理器播放
-      this.backgroundAudioManager.title = item.title || '未知音频'
-      this.backgroundAudioManager.singer = item.subtitle || '冥想音乐'
-      this.backgroundAudioManager.coverImgUrl = item.cover || '/static/images/default-cover.jpg'
-      this.backgroundAudioManager.epname = item.title || '冥想音频'
-      
-      // 设置音频源，这会自动开始播放
-      this.backgroundAudioManager.src = item.audioUrl
-      
-      // 保存当前播放的音轨ID，供迷你播放器使用
-      uni.setStorageSync('currentTrackId', item.targetId)
+      // 跳转到播放器页面，传递收藏列表
+      uni.navigateTo({
+        url: `/pages/player/index?id=${item.targetId}&source=favorites&list=${listData}`
+      })
     },
     
     // 暂停音频

--- a/meditation-uniapp/pages/history/index.vue
+++ b/meditation-uniapp/pages/history/index.vue
@@ -260,12 +260,21 @@ export default {
     
     // 播放音频
     playAudio(item) {
-      // 跳转到播放页面，传递播放进度信息
+      // 获取所有历史记录（扁平化）
+      const allHistory = []
+      this.historyGroups.forEach(group => {
+        allHistory.push(...group.items)
+      })
+      
+      // 准备列表数据
+      const listData = encodeURIComponent(JSON.stringify(allHistory))
+      
+      // 跳转到播放页面，传递历史列表和播放进度信息
       const params = {
         id: item.trackId,
-        title: encodeURIComponent(item.title),
-        progress: item.progressSec,
-        totalDuration: item.duration
+        source: 'history',
+        list: listData,
+        progress: item.progressSec
       }
       
       // 如果有系列ID，也传递过去
@@ -297,11 +306,20 @@ export default {
             this.playAudio(item)
           } else if (res.tapIndex === 1) {
             // 从头播放
+            // 获取所有历史记录（扁平化）
+            const allHistory = []
+            this.historyGroups.forEach(group => {
+              allHistory.push(...group.items)
+            })
+            
+            // 准备列表数据
+            const listData = encodeURIComponent(JSON.stringify(allHistory))
+            
             const params = {
               id: item.trackId,
-              title: encodeURIComponent(item.title),
-              progress: 0,
-              totalDuration: item.duration
+              source: 'history',
+              list: listData,
+              progress: 0  // 从头开始播放
             }
             
             // 如果有系列ID，也传递过去

--- a/meditation-uniapp/pages/history/index.vue
+++ b/meditation-uniapp/pages/history/index.vue
@@ -260,20 +260,10 @@ export default {
     
     // 播放音频
     playAudio(item) {
-      // 获取所有历史记录（扁平化）
-      const allHistory = []
-      this.historyGroups.forEach(group => {
-        allHistory.push(...group.items)
-      })
-      
-      // 准备列表数据
-      const listData = encodeURIComponent(JSON.stringify(allHistory))
-      
-      // 跳转到播放页面，传递历史列表和播放进度信息
+      // 跳转到播放页面，传递播放进度信息
       const params = {
         id: item.trackId,
         source: 'history',
-        list: listData,
         progress: item.progressSec
       }
       
@@ -306,19 +296,9 @@ export default {
             this.playAudio(item)
           } else if (res.tapIndex === 1) {
             // 从头播放
-            // 获取所有历史记录（扁平化）
-            const allHistory = []
-            this.historyGroups.forEach(group => {
-              allHistory.push(...group.items)
-            })
-            
-            // 准备列表数据
-            const listData = encodeURIComponent(JSON.stringify(allHistory))
-            
             const params = {
               id: item.trackId,
               source: 'history',
-              list: listData,
               progress: 0  // 从头开始播放
             }
             

--- a/meditation-uniapp/pages/history/index.vue
+++ b/meditation-uniapp/pages/history/index.vue
@@ -260,11 +260,10 @@ export default {
     
     // 播放音频
     playAudio(item) {
-      // 跳转到播放页面，传递播放进度信息
+      // 跳转到播放页面
       const params = {
         id: item.trackId,
-        source: 'history',
-        progress: item.progressSec
+        source: 'history'
       }
       
       // 如果有系列ID，也传递过去
@@ -298,8 +297,7 @@ export default {
             // 从头播放
             const params = {
               id: item.trackId,
-              source: 'history',
-              progress: 0  // 从头开始播放
+              source: 'history'
             }
             
             // 如果有系列ID，也传递过去

--- a/meditation-uniapp/pages/home/index.vue
+++ b/meditation-uniapp/pages/home/index.vue
@@ -347,9 +347,9 @@ export default {
 
     // 跳转到冥想详情
     goToMeditation(item) {
-      // 跳转到系列详情页（series是系列，不是单个音轨）
+      // 跳转到播放器页面，播放系列的第一个音频，并加载整个系列作为播放列表
       uni.navigateTo({
-        url: `/pages/series/detail?id=${item.id}`
+        url: `/pages/player/index?seriesId=${item.id}&type=series`
       })
     },
 

--- a/meditation-uniapp/pages/home/index.vue
+++ b/meditation-uniapp/pages/home/index.vue
@@ -347,9 +347,9 @@ export default {
 
     // 跳转到冥想详情
     goToMeditation(item) {
-      // 跳转到系列详情页
+      // 跳转到系列详情页（series是系列，不是单个音轨）
       uni.navigateTo({
-        url: `/pages/player/index?id=${item.id}`
+        url: `/pages/series/detail?id=${item.id}`
       })
     },
 

--- a/meditation-uniapp/pages/me/index.vue
+++ b/meditation-uniapp/pages/me/index.vue
@@ -1,9 +1,9 @@
 <template>
   <view class="me-page">
-    <!-- 顶部背景 -->
-    <view class="header-bg">
-      <image src="/static/me/background@3x.png" mode="aspectFill" class="bg-image"></image>
-    </view>
+    <!-- 顶部导航栏占位 -->
+    <view class="topNav" :style="{ height: navHeight + 'px', paddingTop: statusBarHeight + 'px' }"></view>
+    <!-- 背景图 -->
+    <image src="/static/home/background@3x.png" class="background-image" mode="widthFix"></image>
 
     <!-- 主要内容区域 -->
     <view class="main-content">
@@ -79,12 +79,26 @@ import { mapState, mapActions } from 'vuex'
 export default {
   data() {
     return {
-
+      navHeight: "", // 导航栏高度
+      statusBarHeight: '', // 状态栏高度
     }
   },
 
   computed: {
     ...mapState('user', ['isLogin', 'token', 'userInfo'])
+  },
+
+  onLoad() {
+    // 获取手机系统的信息 里面有状态栏高度和设备型号
+    let {
+      statusBarHeight,
+      system
+    } = uni.getSystemInfoSync()
+    // 注意返回的单位是px 不是rpx
+    this.statusBarHeight = statusBarHeight
+    // 而导航栏的高度则 = 状态栏的高度 + 判断机型的值（是ios就+40，否则+44）
+    // 这个高度刚好和胶囊对齐
+    this.navHeight = statusBarHeight + (system.indexOf('iOS') > -1 ? 40 : 44)
   },
 
   onShow() {
@@ -202,44 +216,44 @@ export default {
 <style lang="scss" scoped>
 .me-page {
   min-height: 100vh;
-  background: #F5F7FA;
+  background: #D8E2F0;
   position: relative;
 }
 
-// 顶部背景
-.header-bg {
-  width: 100%;
-  height: 320rpx;
+// 顶部导航栏占位
+.topNav {
   position: relative;
-  overflow: hidden;
-  background: linear-gradient(135deg, #7C3AED, #A855F7);
+  z-index: 1;
+}
 
-  .bg-image {
-    width: 100%;
-    height: 100%;
-    display: block;
-    opacity: 0.3;
-  }
+// 背景图
+.background-image {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 0;
+  opacity: 1;
 }
 
 // 主要内容区域
 .main-content {
-  margin-top: -100rpx;
-  padding: 0 30rpx 100rpx;
+  padding: 20rpx 30rpx 100rpx;
   position: relative;
-  z-index: 10;
+  z-index: 1;
 }
 
 // 用户信息卡片 - 左右布局
 .user-card {
-  background: #FFFFFF;
+  background: rgba(255, 255, 255, 0.95);
   border-radius: 24rpx;
   padding: 30rpx;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  box-shadow: 0 8rpx 24rpx rgba(124, 58, 237, 0.1);
+  box-shadow: 0 4rpx 16rpx rgba(0, 0, 0, 0.08);
   margin-bottom: 30rpx;
+  margin-top: 20rpx;
 
   .user-info {
     display: flex;
@@ -291,10 +305,10 @@ export default {
 
 // 功能菜单列表
 .menu-list {
-  background: #FFFFFF;
+  background: rgba(255, 255, 255, 0.95);
   border-radius: 24rpx;
   overflow: hidden;
-  box-shadow: 0 4rpx 12rpx rgba(0, 0, 0, 0.04);
+  box-shadow: 0 4rpx 16rpx rgba(0, 0, 0, 0.08);
   margin-bottom: 30rpx;
 
   .menu-item {
@@ -342,10 +356,10 @@ export default {
 
 // 设置区域 - 合并的部分
 .settings-section {
-  background: #FFFFFF;
+  background: rgba(255, 255, 255, 0.95);
   border-radius: 24rpx;
   overflow: hidden;
-  box-shadow: 0 4rpx 12rpx rgba(0, 0, 0, 0.04);
+  box-shadow: 0 4rpx 16rpx rgba(0, 0, 0, 0.08);
 
   .setting-item {
     height: 110rpx;

--- a/meditation-uniapp/pages/player/index.vue
+++ b/meditation-uniapp/pages/player/index.vue
@@ -1224,7 +1224,7 @@ export default {
     width: 110%;
     height: 110%;
     margin: -5%;
-    filter: blur(1rpx) brightness(1) saturate(1);
+    filter: blur(20rpx) brightness(0.8) saturate(1.2);
     transform: scale(1.1);
     animation: slowZoom 20s ease-in-out infinite alternate;
   }

--- a/meditation-uniapp/pages/player/index.vue
+++ b/meditation-uniapp/pages/player/index.vue
@@ -188,7 +188,7 @@
 <script>
 import { getTrackDetail, recordPlay, listTracks } from '@/api/track'
 import { addFavorite, removeFavorite, checkFavorite, listFavorites } from '@/api/favorite'
-import { addPlayHistory, updatePlayHistory } from '@/api/play'
+import { addPlayHistory, updatePlayHistory, listPlayHistoryDetail } from '@/api/play'
 import { mapState, mapGetters, mapActions } from 'vuex'
 
 export default {
@@ -274,24 +274,32 @@ export default {
     }
 
     // 处理不同的播放模式
-    if (this.playlistSource === 'history' || this.playlistSource === 'favorites') {
-      // 从历史或收藏进入
-      if (this.sourceList && this.sourceList.length > 0) {
-        // 如果指定了音频ID，找到对应的音频
-        if (options.id) {
-          this.trackId = options.id
-          // 在列表中找到对应的索引
-          const index = this.sourceList.findIndex(item => 
-            String(item.trackId || item.targetId || item.id) === String(options.id)
-          )
-          if (index !== -1) {
-            this.currentIndex = index
-          }
-        } else {
-          // 没有指定音频，播放列表第一个
-          const firstItem = this.sourceList[0]
-          this.trackId = firstItem.trackId || firstItem.targetId || firstItem.id
+    if (this.playlistSource === 'history') {
+      // 从历史进入，需要加载历史列表
+      if (options.id) {
+        this.trackId = options.id
+      } else {
+        // 如果没有指定ID，稍后从历史列表中获取第一个
+        const historyList = await this.loadHistoryList()
+        if (historyList && historyList.length > 0) {
+          this.trackId = historyList[0].id || historyList[0].trackId
           this.currentIndex = 0
+        } else {
+          throw new Error('暂无播放历史')
+        }
+      }
+    } else if (this.playlistSource === 'favorites') {
+      // 从收藏进入，需要加载收藏列表
+      if (options.id) {
+        this.trackId = options.id
+      } else {
+        // 如果没有指定ID，从收藏列表中获取第一个
+        const favoritesList = await this.loadFavoritesList()
+        if (favoritesList && favoritesList.length > 0) {
+          this.trackId = favoritesList[0].id || favoritesList[0].trackId
+          this.currentIndex = 0
+        } else {
+          throw new Error('暂无收藏')
         }
       }
     } else if (options.type === 'series' && options.seriesId) {
@@ -480,6 +488,76 @@ export default {
       } catch (error) {
         console.error('加载系列音频失败:', error)
         throw error
+      }
+    },
+    
+    // 加载播放历史列表
+    async loadHistoryList() {
+      try {
+        const params = {
+          pageNum: 1,
+          pageSize: 100,
+          orderByColumn: 'last_play_time',
+          isAsc: 'desc'
+        }
+        const res = await listPlayHistoryDetail(params)
+        if (res.code === 200) {
+          const list = res.rows || res.data || []
+          // 格式化历史数据
+          return list.map(item => {
+            const track = item.track || {}
+            return {
+              id: track.id || item.trackId,
+              trackId: item.trackId,
+              title: track.title || item.trackTitle || '未知音频',
+              artist: track.subtitle || track.author || '冥想音乐',
+              durationSec: track.durationSec || item.duration || 0,
+              audioUrl: track.audioUrl || track.audio,
+              coverUrl: track.coverUrl || item.cover || '/static/images/default-cover.jpg',
+              progressSec: item.progressSec || 0,
+              seriesId: item.seriesId,
+              categoryCode: track.categoryCode
+            }
+          })
+        }
+        return []
+      } catch (error) {
+        console.log('加载历史列表失败（已忽略）')
+        return []
+      }
+    },
+    
+    // 加载收藏列表
+    async loadFavoritesList() {
+      try {
+        const params = {
+          pageNum: 1,
+          pageSize: 100,
+          orderByColumn: 'create_time',
+          isAsc: 'desc'
+        }
+        const res = await listFavorites(params)
+        if (res.code === 200) {
+          const list = res.rows || res.data || []
+          // 只返回音频类型的收藏
+          return list
+            .filter(item => item.targetType === 'track')
+            .map(item => ({
+              id: item.targetId,
+              trackId: item.targetId,
+              title: item.title || '未知音频',
+              artist: item.subtitle || '冥想音乐',
+              durationSec: item.duration || 0,
+              audioUrl: item.audioUrl,
+              coverUrl: item.cover || '/static/images/default-cover.jpg',
+              seriesId: item.seriesId,
+              categoryCode: item.categoryCode
+            }))
+        }
+        return []
+      } catch (error) {
+        console.log('加载收藏列表失败（已忽略）')
+        return []
       }
     },
     
@@ -871,21 +949,12 @@ export default {
         let tracks = []
         
         // 根据不同来源加载播放列表
-        if (this.playlistSource === 'history' || this.playlistSource === 'favorites') {
-          // 使用传入的源列表
-          if (this.sourceList && this.sourceList.length > 0) {
-            // 格式化源列表数据
-            tracks = this.sourceList.map(item => ({
-              id: item.trackId || item.targetId || item.id,
-              title: item.title || item.trackTitle || '未知音频',
-              artist: item.subtitle || item.author || '冥想音乐',
-              durationSec: item.durationSec || item.duration || 0,
-              audioUrl: item.audioUrl || item.audio,
-              coverUrl: item.coverUrl || item.cover || '/static/images/default-cover.jpg',
-              categoryCode: item.categoryCode,
-              seriesId: item.seriesId
-            }))
-          }
+        if (this.playlistSource === 'history') {
+          // 从API加载历史列表
+          tracks = await this.loadHistoryList()
+        } else if (this.playlistSource === 'favorites') {
+          // 从API加载收藏列表
+          tracks = await this.loadFavoritesList()
         } else {
           // 原有的逻辑：从API加载
           let params = {

--- a/meditation-uniapp/pages/player/index.vue
+++ b/meditation-uniapp/pages/player/index.vue
@@ -225,6 +225,8 @@ export default {
   },
 
   async onLoad(options) {
+    console.log('播放器页面 onLoad 参数:', options)
+    
     //获取手机系统的信息 里面有状态栏高度和设备型号
     let {
       statusBarHeight,
@@ -238,9 +240,30 @@ export default {
     this.navHeight = statusBarHeight + (system.indexOf('iOS') > -1 ? 40 : 44)
     console.log(this.navHeight, "导航栏高度");
 
+    // 检查是否传入了有效的 ID
+    if (!options.id) {
+      console.error('播放器页面错误：未传入音轨ID')
+      uni.showToast({
+        title: '参数错误：缺少音轨ID',
+        icon: 'none',
+        duration: 2000
+      })
+      // 延迟返回上一页
+      setTimeout(() => {
+        uni.navigateBack()
+      }, 2000)
+      return
+    }
+
     this.trackId = options.id
     this.seriesId = options.seriesId || null
     this.categoryId = options.categoryId || null
+
+    console.log('音轨信息:', {
+      trackId: this.trackId,
+      seriesId: this.seriesId,
+      categoryId: this.categoryId
+    })
 
     // 重置收藏状态
     this.isFavorite = false
@@ -435,7 +458,17 @@ export default {
 
     async loadTrack() {
       try {
+        console.log('开始加载音轨，ID:', this.trackId)
+        
+        // 显示加载提示
+        uni.showLoading({
+          title: '加载中...',
+          mask: true
+        })
+        
         const res = await getTrackDetail(this.trackId)
+        
+        console.log('音轨详情API响应:', res)
 
         if (res.code === 200 && res.data) {
           // 映射后端返回的数据字段
@@ -450,6 +483,8 @@ export default {
             categoryId: res.data.categoryId,
             seriesId: res.data.seriesId
           }
+          
+          console.log('处理后的音轨数据:', this.track)
 
           // 设置seriesId和categoryId如果没有传入
           if (!this.seriesId && res.data.seriesId) {
@@ -510,6 +545,11 @@ export default {
                 this.audioContext.seek(this.currentTime)
               }, 100)
             }
+            
+            // 隐藏加载提示
+            uni.hideLoading()
+          } else {
+            throw new Error('音频URL不存在')
           }
         } else {
           throw new Error(res.msg || '获取音频信息失败')
@@ -522,10 +562,20 @@ export default {
         this.addToPlayHistory()
       } catch (error) {
         console.error('加载音频失败:', error)
+        
+        // 隐藏加载提示
+        uni.hideLoading()
+        
         uni.showToast({
-          title: '加载失败',
-          icon: 'none'
+          title: error.message || '加载失败',
+          icon: 'none',
+          duration: 2000
         })
+        
+        // 如果加载失败，延迟返回上一页
+        setTimeout(() => {
+          uni.navigateBack()
+        }, 2000)
       }
     },
 

--- a/meditation-uniapp/pages/player/index.vue
+++ b/meditation-uniapp/pages/player/index.vue
@@ -240,11 +240,11 @@ export default {
     this.navHeight = statusBarHeight + (system.indexOf('iOS') > -1 ? 40 : 44)
     console.log(this.navHeight, "导航栏高度");
 
-    // 检查是否传入了有效的 ID
-    if (!options.id) {
-      console.error('播放器页面错误：未传入音轨ID')
+    // 检查参数：支持直接传入音轨ID或系列ID
+    if (!options.id && !options.seriesId) {
+      console.error('播放器页面错误：未传入音轨ID或系列ID')
       uni.showToast({
-        title: '参数错误：缺少音轨ID',
+        title: '参数错误：缺少必要参数',
         icon: 'none',
         duration: 2000
       })
@@ -255,9 +255,39 @@ export default {
       return
     }
 
-    this.trackId = options.id
-    this.seriesId = options.seriesId || null
-    this.categoryId = options.categoryId || null
+    // 如果是系列类型，需要先获取系列的第一个音频
+    if (options.type === 'series' && options.seriesId) {
+      console.log('系列播放模式，系列ID:', options.seriesId)
+      this.seriesId = options.seriesId
+      
+      // 先加载系列的音频列表
+      try {
+        const tracks = await this.loadSeriesTracks(options.seriesId)
+        if (tracks && tracks.length > 0) {
+          // 使用系列的第一个音频作为当前播放音频
+          this.trackId = tracks[0].id
+          console.log('系列第一个音频ID:', this.trackId)
+        } else {
+          throw new Error('该系列暂无音频')
+        }
+      } catch (error) {
+        console.error('加载系列音频失败:', error)
+        uni.showToast({
+          title: error.message || '加载失败',
+          icon: 'none',
+          duration: 2000
+        })
+        setTimeout(() => {
+          uni.navigateBack()
+        }, 2000)
+        return
+      }
+    } else {
+      // 单个音频播放模式
+      this.trackId = options.id
+      this.seriesId = options.seriesId || null
+      this.categoryId = options.categoryId || null
+    }
 
     console.log('音轨信息:', {
       trackId: this.trackId,
@@ -380,6 +410,29 @@ export default {
   methods: {
     ...mapActions('timer', ['startSleepTimer', 'stopSleepTimer']),
     ...mapActions('playlist', ['setPlaylistAndPlay', 'playNext', 'playPrevious', 'togglePlayMode', 'addAndPlay']),
+    
+    // 加载系列的音频列表
+    async loadSeriesTracks(seriesId) {
+      try {
+        const params = {
+          seriesId: seriesId,
+          status: 0,
+          orderByColumn: 'order_index',
+          isAsc: 'asc',
+          pageNum: 1,
+          pageSize: 100
+        }
+        const res = await listTracks(params)
+        if (res.code === 200) {
+          return res.rows || res.data || []
+        }
+        return []
+      } catch (error) {
+        console.error('加载系列音频失败:', error)
+        throw error
+      }
+    },
+    
     initAudio() {
       // 使用后台音频管理器，支持后台播放
       this.audioContext = uni.getBackgroundAudioManager()

--- a/meditation-uniapp/pages/player/index.vue
+++ b/meditation-uniapp/pages/player/index.vue
@@ -211,6 +211,8 @@ export default {
       playlist: [], // 播放列表，从API获取
       seriesId: null, // 系列ID
       categoryId: null, // 分类ID
+      playlistSource: 'default', // 播放列表来源: default/history/favorites/series
+      sourceList: [], // 来源列表数据（历史/收藏等）
       selectedTime: 5, // 默认选中5分钟
       customTime: 0,   // 自定义时间
       showCustomModal: false, // 是否显示自定义模态框
@@ -240,9 +242,25 @@ export default {
     this.navHeight = statusBarHeight + (system.indexOf('iOS') > -1 ? 40 : 44)
     console.log(this.navHeight, "导航栏高度");
 
-    // 检查参数：支持直接传入音轨ID或系列ID
-    if (!options.id && !options.seriesId) {
-      console.error('播放器页面错误：未传入音轨ID或系列ID')
+    // 识别播放列表来源
+    if (options.source) {
+      this.playlistSource = options.source // history/favorites/series/default
+      console.log('播放列表来源:', this.playlistSource)
+    }
+    
+    // 如果传入了源数据列表（如历史记录或收藏列表）
+    if (options.list) {
+      try {
+        this.sourceList = JSON.parse(decodeURIComponent(options.list))
+        console.log('源列表数据:', this.sourceList.length, '条')
+      } catch (error) {
+        console.error('解析源列表数据失败:', error)
+      }
+    }
+    
+    // 检查参数：支持直接传入音轨ID或系列ID，或者使用列表
+    if (!options.id && !options.seriesId && (!this.sourceList || this.sourceList.length === 0)) {
+      console.error('播放器页面错误：未传入有效参数')
       uni.showToast({
         title: '参数错误：缺少必要参数',
         icon: 'none',
@@ -255,18 +273,50 @@ export default {
       return
     }
 
-    // 如果是系列类型，需要先获取系列的第一个音频
-    if (options.type === 'series' && options.seriesId) {
+    // 处理不同的播放模式
+    if (this.playlistSource === 'history' || this.playlistSource === 'favorites') {
+      // 从历史或收藏进入
+      if (this.sourceList && this.sourceList.length > 0) {
+        // 如果指定了音频ID，找到对应的音频
+        if (options.id) {
+          this.trackId = options.id
+          // 在列表中找到对应的索引
+          const index = this.sourceList.findIndex(item => 
+            String(item.trackId || item.targetId || item.id) === String(options.id)
+          )
+          if (index !== -1) {
+            this.currentIndex = index
+          }
+        } else {
+          // 没有指定音频，播放列表第一个
+          const firstItem = this.sourceList[0]
+          this.trackId = firstItem.trackId || firstItem.targetId || firstItem.id
+          this.currentIndex = 0
+        }
+      }
+    } else if (options.type === 'series' && options.seriesId) {
+      // 系列播放模式
       console.log('系列播放模式，系列ID:', options.seriesId)
       this.seriesId = options.seriesId
+      this.playlistSource = 'series'
       
       // 先加载系列的音频列表
       try {
         const tracks = await this.loadSeriesTracks(options.seriesId)
         if (tracks && tracks.length > 0) {
-          // 使用系列的第一个音频作为当前播放音频
-          this.trackId = tracks[0].id
-          console.log('系列第一个音频ID:', this.trackId)
+          // 如果指定了音频ID
+          if (options.id) {
+            this.trackId = options.id
+            const index = tracks.findIndex(item => String(item.id) === String(options.id))
+            if (index !== -1) {
+              this.currentIndex = index
+            }
+          } else {
+            // 使用系列的第一个音频作为当前播放音频
+            this.trackId = tracks[0].id
+            this.currentIndex = 0
+          }
+          console.log('系列音频ID:', this.trackId, '索引:', this.currentIndex)
         } else {
           throw new Error('该系列暂无音频')
         }
@@ -815,39 +865,64 @@ export default {
     // 加载播放列表
     async loadPlaylist() {
       try {
-        let params = {
-          status: 0,
-          pageNum: 1,
-          pageSize: 100
+        let tracks = []
+        
+        // 根据不同来源加载播放列表
+        if (this.playlistSource === 'history' || this.playlistSource === 'favorites') {
+          // 使用传入的源列表
+          if (this.sourceList && this.sourceList.length > 0) {
+            // 格式化源列表数据
+            tracks = this.sourceList.map(item => ({
+              id: item.trackId || item.targetId || item.id,
+              title: item.title || item.trackTitle || '未知音频',
+              artist: item.subtitle || item.author || '冥想音乐',
+              durationSec: item.durationSec || item.duration || 0,
+              audioUrl: item.audioUrl || item.audio,
+              coverUrl: item.coverUrl || item.cover || '/static/images/default-cover.jpg',
+              categoryCode: item.categoryCode,
+              seriesId: item.seriesId
+            }))
+          }
+        } else {
+          // 原有的逻辑：从API加载
+          let params = {
+            status: 0,
+            pageNum: 1,
+            pageSize: 100
+          }
+
+          // 如果有系列ID，获取同系列的音频
+          if (this.seriesId) {
+            params.seriesId = this.seriesId
+            params.orderByColumn = 'order_index'
+            params.isAsc = 'asc'
+          }
+          // 如果有分类ID，获取同分类的音频
+          else if (this.categoryId) {
+            params.categoryId = this.categoryId
+            params.orderByColumn = 'create_time'
+            params.isAsc = 'desc'
+          }
+          // 否则获取推荐音频（适用于从首页冥想推荐进入的情况）
+          else {
+            params.orderByColumn = 'create_time'  // 使用创建时间排序
+            params.isAsc = 'desc'  // 最新的在前
+            params.pageSize = 50  // 限制数量，获取最新推荐
+          }
+
+          const res = await listTracks(params)
+          if (res.code === 200) {
+            tracks = res.rows || res.data || []
+          }
         }
 
-        // 如果有系列ID，获取同系列的音频
-        if (this.seriesId) {
-          params.seriesId = this.seriesId
-          params.orderByColumn = 'order_index'
-          params.isAsc = 'asc'
-        }
-        // 如果有分类ID，获取同分类的音频
-        else if (this.categoryId) {
-          params.categoryId = this.categoryId
-          params.orderByColumn = 'create_time'
-          params.isAsc = 'desc'
-        }
-        // 否则获取推荐音频（适用于从首页冥想推荐进入的情况）
-        else {
-          params.orderByColumn = 'create_time'  // 使用创建时间排序
-          params.isAsc = 'desc'  // 最新的在前
-          params.pageSize = 50  // 限制数量，获取最新推荐
-        }
-
-        const res = await listTracks(params)
-
-        if (res.code === 200) {
-          const tracks = res.rows || res.data || []
-          
+        // 处理播放列表
+        if (tracks && tracks.length > 0) {
           // 如果当前音频不在列表中，将其添加到列表开头
           let finalTracks = [...tracks]
-          const currentTrackInList = tracks.find(item => item.id === parseInt(this.trackId))
+          const currentTrackInList = tracks.find(item => 
+            String(item.id) === String(this.trackId)
+          )
           
           if (!currentTrackInList && this.track) {
             // 将当前播放的音频添加到列表开头

--- a/meditation-uniapp/pages/player/index.vue
+++ b/meditation-uniapp/pages/player/index.vue
@@ -695,7 +695,8 @@ export default {
           this.playHistoryId = res.data.id
         }
       } catch (error) {
-        console.error('添加播放历史失败:', error)
+        // 静默处理错误，不显示提示
+        console.log('播放历史记录失败（已忽略）')
       }
     },
 
@@ -732,7 +733,8 @@ export default {
           isCompleted: isCompleted
         })
       } catch (error) {
-        console.error('更新播放进度失败:', error)
+        // 静默处理错误，不显示提示
+        console.log('更新播放进度失败（已忽略）')
       }
     },
 
@@ -748,7 +750,8 @@ export default {
           isCompleted: '1'
         })
       } catch (error) {
-        console.error('标记完成失败:', error)
+        // 静默处理错误，不显示提示
+        console.log('标记完成失败（已忽略）')
       }
     },
 

--- a/meditation-uniapp/pages/player/index.vue
+++ b/meditation-uniapp/pages/player/index.vue
@@ -691,11 +691,33 @@ export default {
             // 设置其他可选属性
             this.audioContext.epname = this.track.title || '冥想音频' // 专辑名，选填
             this.audioContext.singer = this.track.artist || '冥想音乐' // 歌手名，选填
-            this.audioContext.coverImgUrl = this.track.coverUrl || '/static/images/default-cover.jpg' // 封面图，选填
+            
+            // 处理封面图URL
+            let coverUrl = '/static/images/default-cover.jpg'
+            if (this.track.coverUrl) {
+              if (this.track.coverUrl.startsWith('http://') || this.track.coverUrl.startsWith('https://')) {
+                coverUrl = this.track.coverUrl
+              } else {
+                // 需要拼接完整路径
+                coverUrl = `${this.$baseUrl}/system/oss/download/${this.track.coverUrl}`
+              }
+            }
+            this.audioContext.coverImgUrl = coverUrl // 封面图，选填
 
+            // 处理音频URL
+            let audioUrl = ''
+            if (this.track.audioUrl) {
+              if (this.track.audioUrl.startsWith('http://') || this.track.audioUrl.startsWith('https://')) {
+                audioUrl = this.track.audioUrl
+              } else {
+                // 需要拼接完整路径
+                audioUrl = `${this.$baseUrl}/system/oss/download/${this.track.audioUrl}`
+              }
+            }
+            
             // 最后设置 src，这会触发音频加载
             // 注意：src 必须最后设置
-            this.audioContext.src = this.track.audioUrl
+            this.audioContext.src = audioUrl
 
             console.log('音频信息设置完成:', {
               src: this.audioContext.src,
@@ -1074,11 +1096,31 @@ export default {
         // 设置其他可选属性
         this.audioContext.epname = track.name || '冥想音频' // 专辑名
         this.audioContext.singer = track.artist || '冥想音乐' // 歌手名
-        this.audioContext.coverImgUrl = track.coverUrl || '/static/images/default-cover.jpg' // 封面图
+        
+        // 处理封面图URL
+        let coverUrl = '/static/images/default-cover.jpg'
+        if (track.coverUrl) {
+          if (track.coverUrl.startsWith('http://') || track.coverUrl.startsWith('https://')) {
+            coverUrl = track.coverUrl
+          } else {
+            coverUrl = `${this.$baseUrl}/system/oss/download/${track.coverUrl}`
+          }
+        }
+        this.audioContext.coverImgUrl = coverUrl // 封面图
+
+        // 处理音频URL
+        let audioUrl = ''
+        if (track.audioUrl) {
+          if (track.audioUrl.startsWith('http://') || track.audioUrl.startsWith('https://')) {
+            audioUrl = track.audioUrl
+          } else {
+            audioUrl = `${this.$baseUrl}/system/oss/download/${track.audioUrl}`
+          }
+        }
 
         // 最后设置 src，这会触发音频加载
         // 注意：src 必须最后设置
-        this.audioContext.src = track.audioUrl
+        this.audioContext.src = audioUrl
 
         // 保存当前播放的音轨ID
         uni.setStorageSync('currentTrackId', track.id)

--- a/meditation-uniapp/pages/search/index.vue
+++ b/meditation-uniapp/pages/search/index.vue
@@ -176,8 +176,9 @@
 				})
 			},
 			goSeries(id) {
+				// 直接跳转到播放器，播放系列的第一个音频
 				uni.navigateTo({
-					url: `/pages/series/detail?id=${id}`
+					url: `/pages/player/index?seriesId=${id}&type=series`
 				})
 			},
 			goArticle(id) {

--- a/meditation-uniapp/store/modules/playlist.js
+++ b/meditation-uniapp/store/modules/playlist.js
@@ -170,7 +170,7 @@ const actions = {
   
   // 初始化音频管理器并设置事件监听
   initAudioManager({ commit, dispatch, state }) {
-    // #ifdef MP-WEIXIN || MP-BAIDU || MP-QQ
+    // 统一使用全局唯一的背景音频管理器
     const manager = uni.getBackgroundAudioManager()
     
     // 播放事件
@@ -220,39 +220,6 @@ const actions = {
     
     commit('SET_AUDIO_MANAGER', manager)
     return manager
-    // #endif
-    
-    // #ifndef MP-WEIXIN || MP-BAIDU || MP-QQ
-    const manager = uni.createInnerAudioContext()
-    
-    manager.onPlay(() => {
-      commit('SET_PLAYING', true)
-    })
-    
-    manager.onPause(() => {
-      commit('SET_PLAYING', false)
-    })
-    
-    manager.onEnded(() => {
-      dispatch('playNext')
-    })
-    
-    manager.onError(() => {
-      setTimeout(() => {
-        dispatch('playNext')
-      }, 1000)
-    })
-    
-    manager.onTimeUpdate(() => {
-      commit('SET_PROGRESS', {
-        currentTime: manager.currentTime,
-        duration: manager.duration
-      })
-    })
-    
-    commit('SET_AUDIO_MANAGER', manager)
-    return manager
-    // #endif
   },
   
   // 播放指定音频

--- a/meditation-uniapp/store/modules/playlist.js
+++ b/meditation-uniapp/store/modules/playlist.js
@@ -235,8 +235,29 @@ const actions = {
     
     // 获取音频URL
     const baseUrl = rootState.app.baseUrl || ''
-    const audioUrl = track.audioUrl ? `${baseUrl}/system/oss/download/${track.audioUrl}` : ''
-    const coverUrl = track.coverUrl ? `${baseUrl}/system/oss/download/${track.coverUrl}` : '/static/images/default-cover.jpg'
+    
+    // 判断是否已经是完整的URL
+    let audioUrl = ''
+    if (track.audioUrl) {
+      if (track.audioUrl.startsWith('http://') || track.audioUrl.startsWith('https://')) {
+        // 已经是完整URL，直接使用
+        audioUrl = track.audioUrl
+      } else {
+        // 需要拼接OSS下载路径
+        audioUrl = `${baseUrl}/system/oss/download/${track.audioUrl}`
+      }
+    }
+    
+    let coverUrl = '/static/images/default-cover.jpg'
+    if (track.coverUrl) {
+      if (track.coverUrl.startsWith('http://') || track.coverUrl.startsWith('https://')) {
+        // 已经是完整URL，直接使用
+        coverUrl = track.coverUrl
+      } else {
+        // 需要拼接OSS下载路径
+        coverUrl = `${baseUrl}/system/oss/download/${track.coverUrl}`
+      }
+    }
     
     // #ifdef MP-WEIXIN || MP-BAIDU || MP-QQ
     // 设置背景音频信息

--- a/meditation-uniapp/store/modules/timer.js
+++ b/meditation-uniapp/store/modules/timer.js
@@ -63,17 +63,10 @@ const mutations = {
 const actions = {
   // 初始化背景音频管理器
   initAudioManager({ commit }) {
-    // #ifdef MP-WEIXIN || MP-BAIDU || MP-QQ
+    // 统一使用全局唯一的背景音频管理器
     const manager = uni.getBackgroundAudioManager()
     commit('SET_AUDIO_MANAGER', manager)
     return manager
-    // #endif
-    
-    // #ifndef MP-WEIXIN || MP-BAIDU || MP-QQ
-    const manager = uni.createInnerAudioContext()
-    commit('SET_AUDIO_MANAGER', manager)
-    return manager
-    // #endif
   },
   
   // 启动定时器


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Correct home page navigation for series items and enhance player page error handling to fix data loading issues.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, clicking on a meditation series item from the home page incorrectly navigated directly to the player page, passing a series ID instead of a track ID. This caused data loading failures on the player page. This PR redirects series clicks to the series detail page and adds robust ID validation, loading indicators, and improved error messages to the player page for a more stable user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a647950-256a-463f-a48b-d1d2a3d3f00e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1a647950-256a-463f-a48b-d1d2a3d3f00e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

