### PR TITLE
Fix incomplete recommendation item display

### DIFF
--- a/meditation-web-ts/src/api/meditation/recommendItem/types.ts
+++ b/meditation-web-ts/src/api/meditation/recommendItem/types.ts
@@ -1,3 +1,8 @@
+// 引入其他内容类型
+import { SeriesVO } from '../series/types';
+import { ArticleVO } from '../article/types';
+import { TrackVO } from '../track/types';
+
 export interface RecommendItemVO {
   /**
    * 主键
@@ -39,6 +44,20 @@ export interface RecommendItemVO {
    */
   status: string;
 
+  /**
+   * 系列内容详情（当contentType为series时）
+   */
+  seriesContent?: SeriesVO;
+
+  /**
+   * 文章内容详情（当contentType为article时）
+   */
+  articleContent?: ArticleVO;
+
+  /**
+   * 音频内容详情（当contentType为track时）
+   */
+  trackContent?: TrackVO;
 }
 
 export interface RecommendItemForm extends BaseEntity {

--- a/meditation-web-ts/src/views/meditation/recommendItem/index.vue
+++ b/meditation-web-ts/src/views/meditation/recommendItem/index.vue
@@ -106,9 +106,13 @@
                     <el-icon size="12"><VideoPlay /></el-icon>
                     {{ getContentDetail(scope.row).episodeCount }} 小节
                   </span>
-                  <span class="content-extra" v-if="getContentDetail(scope.row).duration">
+                  <span class="content-extra" v-if="getContentDetail(scope.row).recommendDuration">
                     <el-icon size="12"><Clock /></el-icon>
-                    {{ formatDuration(getContentDetail(scope.row).duration) }}
+                    {{ formatDuration(getContentDetail(scope.row).recommendDuration) }}
+                  </span>
+                  <span class="content-extra" v-if="getContentDetail(scope.row).authorName">
+                    <el-icon size="12"><User /></el-icon>
+                    {{ getContentDetail(scope.row).authorName }}
                   </span>
                 </template>
               </div>
@@ -315,8 +319,6 @@ const contentOptions = ref<any[]>([]);
 const queryContentOptions = ref<any[]>([]); // 查询用的内容选项
 const selectedContent = ref<any>(null);
 const contentSearch = ref('');
-// 内容缓存，用于存储已加载的内容详情
-const contentCache = ref<Map<string, any>>(new Map());
 const buttonLoading = ref(false);
 const loading = ref(true);
 const showSearch = ref(true);
@@ -391,10 +393,6 @@ const getList = async () => {
   const res = await listRecommendItem(queryParams.value);
   recommendItemList.value = res.rows;
   total.value = res.total;
-  
-  // 批量加载内容详情
-  await loadContentDetails(res.rows);
-  
   loading.value = false;
 }
 
@@ -414,84 +412,19 @@ const getSlotName = (slotId: string | number) => {
   return slot ? slot.name : slotId;
 }
 
-/** 批量加载内容详情 */
-const loadContentDetails = async (items: RecommendItemVO[]) => {
-  // 按内容类型分组
-  const seriesIds: (string | number)[] = [];
-  const articleIds: (string | number)[] = [];
-  const trackIds: (string | number)[] = [];
-  
-  items.forEach(item => {
-    const cacheKey = `${item.contentType}_${item.contentId}`;
-    // 如果缓存中没有该内容，则需要加载
-    if (!contentCache.value.has(cacheKey)) {
-      switch (item.contentType) {
-        case 'series':
-          seriesIds.push(item.contentId);
-          break;
-        case 'article':
-          articleIds.push(item.contentId);
-          break;
-        case 'track':
-          trackIds.push(item.contentId);
-          break;
-      }
-    }
-  });
-  
-  // 批量加载系列内容
-  if (seriesIds.length > 0) {
-    try {
-      const res = await listSeries({ 
-        ids: seriesIds.join(','),
-        pageNum: 1,
-        pageSize: 100
-      });
-      (res.rows || res.data || []).forEach(series => {
-        contentCache.value.set(`series_${series.id}`, series);
-      });
-    } catch (error) {
-      console.error('加载系列内容失败:', error);
-    }
-  }
-  
-  // 批量加载文章内容
-  if (articleIds.length > 0) {
-    try {
-      const res = await listArticle({ 
-        ids: articleIds.join(','),
-        pageNum: 1,
-        pageSize: 100
-      });
-      (res.rows || res.data || []).forEach(article => {
-        contentCache.value.set(`article_${article.id}`, article);
-      });
-    } catch (error) {
-      console.error('加载文章内容失败:', error);
-    }
-  }
-  
-  // 批量加载音频内容
-  if (trackIds.length > 0) {
-    try {
-      const res = await listTrack({ 
-        ids: trackIds.join(','),
-        pageNum: 1,
-        pageSize: 100
-      });
-      (res.rows || res.data || []).forEach(track => {
-        contentCache.value.set(`track_${track.id}`, track);
-      });
-    } catch (error) {
-      console.error('加载音频内容失败:', error);
-    }
-  }
-}
-
-/** 获取内容详情 */
+/** 获取内容详情 - 从后端返回的嵌套数据中获取 */
 const getContentDetail = (row: RecommendItemVO) => {
-  const cacheKey = `${row.contentType}_${row.contentId}`;
-  return contentCache.value.get(cacheKey);
+  // 根据内容类型返回对应的内容对象
+  switch (row.contentType) {
+    case 'series':
+      return row.seriesContent;
+    case 'article':
+      return row.articleContent;
+    case 'track':
+      return row.trackContent;
+    default:
+      return null;
+  }
 }
 
 /** 获取内容标题 */

--- a/meditation-web-ts/src/views/meditation/recommendItem/index.vue
+++ b/meditation-web-ts/src/views/meditation/recommendItem/index.vue
@@ -91,7 +91,7 @@
             <el-tag v-else>{{ scope.row.contentType }}</el-tag>
           </template>
         </el-table-column>
-        <el-table-column label="内容信息" align="center" prop="contentId" width="300">
+        <el-table-column label="内容信息" align="center" prop="contentId" width="400">
           <template #default="scope">
             <div class="content-info">
               <div class="content-title">{{ getContentTitle(scope.row) }}</div>
@@ -101,6 +101,16 @@
                   {{ getContentTypeLabel(scope.row.contentType) }}
                 </el-tag>
                 <span class="content-id">ID: {{ scope.row.contentId }}</span>
+                <template v-if="getContentDetail(scope.row)">
+                  <span class="content-extra" v-if="getContentDetail(scope.row).episodeCount">
+                    <el-icon size="12"><VideoPlay /></el-icon>
+                    {{ getContentDetail(scope.row).episodeCount }} 小节
+                  </span>
+                  <span class="content-extra" v-if="getContentDetail(scope.row).duration">
+                    <el-icon size="12"><Clock /></el-icon>
+                    {{ formatDuration(getContentDetail(scope.row).duration) }}
+                  </span>
+                </template>
               </div>
             </div>
           </template>
@@ -290,11 +300,12 @@
 <script setup name="RecommendItem" lang="ts">
 import { listRecommendItem, getRecommendItem, delRecommendItem, addRecommendItem, updateRecommendItem } from '@/api/meditation/recommendItem';
 import { listRecommendSlot } from '@/api/meditation/recommendSlot';
-import { listSeries } from '@/api/meditation/series';
-import { listArticle } from '@/api/meditation/article';
-import { listTrack } from '@/api/meditation/track';
+import { listSeries, getSeries } from '@/api/meditation/series';
+import { listArticle, getArticle } from '@/api/meditation/article';
+import { listTrack, getTrack } from '@/api/meditation/track';
 import { RecommendItemVO, RecommendItemQuery, RecommendItemForm } from '@/api/meditation/recommendItem/types';
 import { RecommendSlotVO, RecommendSlotQuery } from '@/api/meditation/recommendSlot/types';
+import { VideoPlay, Clock, User, Calendar } from '@element-plus/icons-vue';
 
 const { proxy } = getCurrentInstance() as ComponentInternalInstance;
 
@@ -304,6 +315,8 @@ const contentOptions = ref<any[]>([]);
 const queryContentOptions = ref<any[]>([]); // 查询用的内容选项
 const selectedContent = ref<any>(null);
 const contentSearch = ref('');
+// 内容缓存，用于存储已加载的内容详情
+const contentCache = ref<Map<string, any>>(new Map());
 const buttonLoading = ref(false);
 const loading = ref(true);
 const showSearch = ref(true);
@@ -378,6 +391,10 @@ const getList = async () => {
   const res = await listRecommendItem(queryParams.value);
   recommendItemList.value = res.rows;
   total.value = res.total;
+  
+  // 批量加载内容详情
+  await loadContentDetails(res.rows);
+  
   loading.value = false;
 }
 
@@ -397,15 +414,108 @@ const getSlotName = (slotId: string | number) => {
   return slot ? slot.name : slotId;
 }
 
+/** 批量加载内容详情 */
+const loadContentDetails = async (items: RecommendItemVO[]) => {
+  // 按内容类型分组
+  const seriesIds: (string | number)[] = [];
+  const articleIds: (string | number)[] = [];
+  const trackIds: (string | number)[] = [];
+  
+  items.forEach(item => {
+    const cacheKey = `${item.contentType}_${item.contentId}`;
+    // 如果缓存中没有该内容，则需要加载
+    if (!contentCache.value.has(cacheKey)) {
+      switch (item.contentType) {
+        case 'series':
+          seriesIds.push(item.contentId);
+          break;
+        case 'article':
+          articleIds.push(item.contentId);
+          break;
+        case 'track':
+          trackIds.push(item.contentId);
+          break;
+      }
+    }
+  });
+  
+  // 批量加载系列内容
+  if (seriesIds.length > 0) {
+    try {
+      const res = await listSeries({ 
+        ids: seriesIds.join(','),
+        pageNum: 1,
+        pageSize: 100
+      });
+      (res.rows || res.data || []).forEach(series => {
+        contentCache.value.set(`series_${series.id}`, series);
+      });
+    } catch (error) {
+      console.error('加载系列内容失败:', error);
+    }
+  }
+  
+  // 批量加载文章内容
+  if (articleIds.length > 0) {
+    try {
+      const res = await listArticle({ 
+        ids: articleIds.join(','),
+        pageNum: 1,
+        pageSize: 100
+      });
+      (res.rows || res.data || []).forEach(article => {
+        contentCache.value.set(`article_${article.id}`, article);
+      });
+    } catch (error) {
+      console.error('加载文章内容失败:', error);
+    }
+  }
+  
+  // 批量加载音频内容
+  if (trackIds.length > 0) {
+    try {
+      const res = await listTrack({ 
+        ids: trackIds.join(','),
+        pageNum: 1,
+        pageSize: 100
+      });
+      (res.rows || res.data || []).forEach(track => {
+        contentCache.value.set(`track_${track.id}`, track);
+      });
+    } catch (error) {
+      console.error('加载音频内容失败:', error);
+    }
+  }
+}
+
+/** 获取内容详情 */
+const getContentDetail = (row: RecommendItemVO) => {
+  const cacheKey = `${row.contentType}_${row.contentId}`;
+  return contentCache.value.get(cacheKey);
+}
+
 /** 获取内容标题 */
 const getContentTitle = (row: RecommendItemVO) => {
-  // 这里可以根据contentType和contentId获取具体内容信息
-  // 暂时返回ID，后续可以优化为显示实际标题
+  const content = getContentDetail(row);
+  if (content) {
+    return content.title || content.name || `ID: ${row.contentId}`;
+  }
   return `ID: ${row.contentId}`;
 }
 
 /** 获取内容副标题 */
 const getContentSubtitle = (row: RecommendItemVO) => {
+  const content = getContentDetail(row);
+  if (content) {
+    // 根据内容类型返回不同的副标题信息
+    if (row.contentType === 'series') {
+      return content.subtitle || content.intro || '系列内容';
+    } else if (row.contentType === 'article') {
+      return content.subtitle || content.summary || '文章内容';
+    } else if (row.contentType === 'track') {
+      return content.subtitle || content.description || '音频内容';
+    }
+  }
   return row.contentType === 'series' ? '系列' : 
          row.contentType === 'article' ? '文章' : 
          row.contentType === 'track' ? '音频' : '';
@@ -757,32 +867,56 @@ onMounted(() => {
   text-align: left;
   
   .content-title {
-    font-weight: 500;
-    margin-bottom: 4px;
+    font-weight: 600;
+    margin-bottom: 6px;
     color: #303133;
-    font-size: 14px;
+    font-size: 15px;
+    line-height: 1.4;
   }
   
   .content-subtitle {
-    font-size: 12px;
-    color: #909399;
-    margin-bottom: 8px;
+    font-size: 13px;
+    color: #606266;
+    margin-bottom: 10px;
+    line-height: 1.5;
+    max-width: 350px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
   }
   
   .content-meta {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 10px;
+    flex-wrap: wrap;
     
     .content-type-tag {
       border-radius: 10px;
-      font-size: 10px;
+      font-size: 11px;
     }
     
     .content-id {
       font-size: 11px;
       color: #c0c4cc;
       font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+    }
+    
+    .content-extra {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      font-size: 11px;
+      color: #909399;
+      padding: 2px 6px;
+      background: #f4f4f5;
+      border-radius: 8px;
+      
+      .el-icon {
+        color: #909399;
+      }
     }
   }
 }

--- a/ruoyi-modules/ruoyi-meditation/src/main/java/org/dromara/meditation/domain/vo/RecommendItemVo.java
+++ b/ruoyi-modules/ruoyi-meditation/src/main/java/org/dromara/meditation/domain/vo/RecommendItemVo.java
@@ -2,6 +2,7 @@ package org.dromara.meditation.domain.vo;
 
 import java.util.Date;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.dromara.meditation.domain.RecommendItem;
 import cn.idev.excel.annotation.ExcelIgnoreUnannotated;
 import cn.idev.excel.annotation.ExcelProperty;
@@ -81,5 +82,23 @@ public class RecommendItemVo implements Serializable {
     @ExcelProperty(value = "状态", converter = ExcelDictConvert.class)
     @ExcelDictFormat(readConverterExp = "0=正常,1=停用")
     private String status;
+
+    /**
+     * 系列内容详情（当contentType为series时）
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private SeriesVo seriesContent;
+
+    /**
+     * 文章内容详情（当contentType为article时）
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private ArticleVo articleContent;
+
+    /**
+     * 音频内容详情（当contentType为track时）
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private TrackVo trackContent;
 
 }

--- a/ruoyi-modules/ruoyi-meditation/src/main/java/org/dromara/meditation/service/impl/RecommendItemServiceImpl.java
+++ b/ruoyi-modules/ruoyi-meditation/src/main/java/org/dromara/meditation/service/impl/RecommendItemServiceImpl.java
@@ -12,13 +12,22 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.dromara.meditation.domain.bo.RecommendItemBo;
 import org.dromara.meditation.domain.vo.RecommendItemVo;
+import org.dromara.meditation.domain.vo.SeriesVo;
+import org.dromara.meditation.domain.vo.ArticleVo;
+import org.dromara.meditation.domain.vo.TrackVo;
 import org.dromara.meditation.domain.RecommendItem;
 import org.dromara.meditation.mapper.RecommendItemMapper;
+import org.dromara.meditation.mapper.SeriesMapper;
+import org.dromara.meditation.mapper.ArticleMapper;
+import org.dromara.meditation.mapper.TrackMapper;
 import org.dromara.meditation.service.IRecommendItemService;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.HashMap;
+import java.util.ArrayList;
 
 /**
  * 推荐位内容Service业务层处理
@@ -32,6 +41,9 @@ import java.util.Collection;
 public class RecommendItemServiceImpl implements IRecommendItemService {
 
     private final RecommendItemMapper baseMapper;
+    private final SeriesMapper seriesMapper;
+    private final ArticleMapper articleMapper;
+    private final TrackMapper trackMapper;
 
     /**
      * 查询推荐位内容
@@ -55,6 +67,12 @@ public class RecommendItemServiceImpl implements IRecommendItemService {
     public TableDataInfo<RecommendItemVo> queryPageList(RecommendItemBo bo, PageQuery pageQuery) {
         LambdaQueryWrapper<RecommendItem> lqw = buildQueryWrapper(bo);
         Page<RecommendItemVo> result = baseMapper.selectVoPage(pageQuery.build(), lqw);
+        
+        // 批量加载内容详情，避免N+1问题
+        if (result.getRecords() != null && !result.getRecords().isEmpty()) {
+            loadContentDetails(result.getRecords());
+        }
+        
         return TableDataInfo.build(result);
     }
 
@@ -67,7 +85,14 @@ public class RecommendItemServiceImpl implements IRecommendItemService {
     @Override
     public List<RecommendItemVo> queryList(RecommendItemBo bo) {
         LambdaQueryWrapper<RecommendItem> lqw = buildQueryWrapper(bo);
-        return baseMapper.selectVoList(lqw);
+        List<RecommendItemVo> list = baseMapper.selectVoList(lqw);
+        
+        // 批量加载内容详情
+        if (list != null && !list.isEmpty()) {
+            loadContentDetails(list);
+        }
+        
+        return list;
     }
 
     private LambdaQueryWrapper<RecommendItem> buildQueryWrapper(RecommendItemBo bo) {
@@ -135,5 +160,87 @@ public class RecommendItemServiceImpl implements IRecommendItemService {
             //TODO 做一些业务上的校验,判断是否需要校验
         }
         return baseMapper.deleteByIds(ids) > 0;
+    }
+    
+    /**
+     * 批量加载内容详情，避免N+1查询问题
+     * 使用批量查询，按内容类型分组一次性加载
+     */
+    private void loadContentDetails(List<RecommendItemVo> items) {
+        if (items == null || items.isEmpty()) {
+            return;
+        }
+        
+        // 按内容类型分组
+        List<Long> seriesIds = new ArrayList<>();
+        List<Long> articleIds = new ArrayList<>();
+        List<Long> trackIds = new ArrayList<>();
+        
+        for (RecommendItemVo item : items) {
+            if (item.getContentId() == null) {
+                continue;
+            }
+            
+            switch (item.getContentType()) {
+                case "series":
+                    seriesIds.add(item.getContentId());
+                    break;
+                case "article":
+                    articleIds.add(item.getContentId());
+                    break;
+                case "track":
+                    trackIds.add(item.getContentId());
+                    break;
+            }
+        }
+        
+        // 批量查询系列内容
+        Map<Long, SeriesVo> seriesMap = new HashMap<>();
+        if (!seriesIds.isEmpty()) {
+            List<SeriesVo> seriesList = seriesMapper.selectVoBatchIds(seriesIds);
+            if (seriesList != null) {
+                seriesMap = seriesList.stream()
+                    .collect(Collectors.toMap(SeriesVo::getId, s -> s, (v1, v2) -> v1));
+            }
+        }
+        
+        // 批量查询文章内容
+        Map<Long, ArticleVo> articleMap = new HashMap<>();
+        if (!articleIds.isEmpty()) {
+            List<ArticleVo> articleList = articleMapper.selectVoBatchIds(articleIds);
+            if (articleList != null) {
+                articleMap = articleList.stream()
+                    .collect(Collectors.toMap(ArticleVo::getId, a -> a, (v1, v2) -> v1));
+            }
+        }
+        
+        // 批量查询音频内容
+        Map<Long, TrackVo> trackMap = new HashMap<>();
+        if (!trackIds.isEmpty()) {
+            List<TrackVo> trackList = trackMapper.selectVoBatchIds(trackIds);
+            if (trackList != null) {
+                trackMap = trackList.stream()
+                    .collect(Collectors.toMap(TrackVo::getId, t -> t, (v1, v2) -> v1));
+            }
+        }
+        
+        // 设置内容详情到对应的推荐项
+        for (RecommendItemVo item : items) {
+            if (item.getContentId() == null) {
+                continue;
+            }
+            
+            switch (item.getContentType()) {
+                case "series":
+                    item.setSeriesContent(seriesMap.get(item.getContentId()));
+                    break;
+                case "article":
+                    item.setArticleContent(articleMap.get(item.getContentId()));
+                    break;
+                case "track":
+                    item.setTrackContent(trackMap.get(item.getContentId()));
+                    break;
+            }
+        }
     }
 }


### PR DESCRIPTION
Display complete content information on the `recommendItem` page by embedding content details directly in the backend VO and updating the frontend.

The `recommendItem` list previously only displayed content IDs. This was due to the backend `RecommendItemVo` not including full content details, which would have led to an N+1 query problem if fetched on the frontend. This PR resolves this by modifying the backend to nest relevant content VOs (SeriesVo, ArticleVo, TrackVo) within `RecommendItemVo` using batch loading for efficiency. The frontend is then updated to consume and display these comprehensive details, improving user experience and performance.

---
<a href="https://cursor.com/background-agent?bcId=bc-c16624b2-dde1-4427-90dc-a7d005e224f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c16624b2-dde1-4427-90dc-a7d005e224f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

