### PR TITLE
Fix infinite loop and playlist repeat bug

### DIFF
--- a/meditation-uniapp/App.vue
+++ b/meditation-uniapp/App.vue
@@ -29,8 +29,8 @@ export default {
 	onShow: function () {
 		console.log('App Show')
 		
-		// 应用显示时恢复定时器
-		this.$store.dispatch('timer/restoreTimer')
+		// onShow不需要重复恢复定时器，已经在onLaunch中处理
+		// this.$store.dispatch('timer/restoreTimer')
 	},
 	onHide: function () {
 		console.log('App Hide')
@@ -330,7 +330,7 @@ export default {
 			this.$store.dispatch('playlist/initAudioManager')
 			this.$store.dispatch('playlist/initPlaylist')
 			
-			// 恢复定时器（如果有）
+			// 恢复定时器（如果有）- 只在这里调用一次
 			this.$store.dispatch('timer/restoreTimer')
 			
 			console.log('全局音频管理器初始化完成')

--- a/meditation-uniapp/store/modules/playlist.js
+++ b/meditation-uniapp/store/modules/playlist.js
@@ -47,11 +47,9 @@ const getters = {
         nextIdx = (nextIdx + 1) % state.playlist.length
       }
       return nextIdx
-    } else if (state.playMode === 'loop') {
-      // 单曲循环
-      return state.currentIndex
     } else {
-      // 顺序播放
+      // 顺序播放和单曲循环都返回下一首的索引
+      // 单曲循环的处理在onEnded事件中处理
       return (state.currentIndex + 1) % state.playlist.length
     }
   },
@@ -67,11 +65,9 @@ const getters = {
         prevIdx = (prevIdx - 1 + state.playlist.length) % state.playlist.length
       }
       return prevIdx
-    } else if (state.playMode === 'loop') {
-      // 单曲循环
-      return state.currentIndex
     } else {
-      // 顺序播放
+      // 顺序播放和单曲循环都返回上一首的索引
+      // 单曲循环的处理在手动切换时处理
       return (state.currentIndex - 1 + state.playlist.length) % state.playlist.length
     }
   }
@@ -191,10 +187,21 @@ const actions = {
       commit('SET_PLAYING', false)
     })
     
-    // 播放结束事件 - 自动播放下一首
+    // 播放结束事件 - 根据播放模式处理
     manager.onEnded(() => {
-      console.log('音频播放结束，准备播放下一首')
-      dispatch('playNext')
+      console.log('音频播放结束')
+      
+      // 如果是单曲循环模式，重新播放当前曲目
+      if (state.playMode === 'loop') {
+        console.log('单曲循环模式，重新播放当前曲目')
+        // 重新设置src以重新播放
+        const currentSrc = manager.src
+        manager.src = currentSrc
+      } else {
+        // 其他模式，播放下一首
+        console.log('准备播放下一首')
+        dispatch('playNext')
+      }
     })
     
     // 错误事件
@@ -282,7 +289,15 @@ const actions = {
       return
     }
     
-    const nextIdx = getters.nextIndex
+    // 单曲循环模式下，手动点击下一首时也应该切换到下一首
+    let nextIdx
+    if (state.playMode === 'loop') {
+      // 单曲循环模式下，手动切换到下一首
+      nextIdx = (state.currentIndex + 1) % state.playlist.length
+    } else {
+      nextIdx = getters.nextIndex
+    }
+    
     if (nextIdx === -1) {
       console.log('没有下一首')
       return
@@ -302,7 +317,15 @@ const actions = {
       return
     }
     
-    const prevIdx = getters.previousIndex
+    // 单曲循环模式下，手动点击上一首时也应该切换到上一首
+    let prevIdx
+    if (state.playMode === 'loop') {
+      // 单曲循环模式下，手动切换到上一首
+      prevIdx = (state.currentIndex - 1 + state.playlist.length) % state.playlist.length
+    } else {
+      prevIdx = getters.previousIndex
+    }
+    
     if (prevIdx === -1) {
       console.log('没有上一首')
       return

--- a/meditation-uniapp/store/modules/timer.js
+++ b/meditation-uniapp/store/modules/timer.js
@@ -148,7 +148,16 @@ const actions = {
   
   // 定时器结束处理
   onTimerEnd({ commit, state, dispatch }) {
+    // 防止重复调用
+    if (!state.isTimerActive) {
+      console.log('定时器已停止，跳过处理')
+      return
+    }
+    
     console.log('定时器时间到，停止播放')
+    
+    // 先清除定时器，防止重复触发
+    dispatch('stopSleepTimer')
     
     // 停止音频播放
     if (state.backgroundAudioManager) {
@@ -159,9 +168,6 @@ const actions = {
       }
     }
     
-    // 清除定时器
-    dispatch('stopSleepTimer')
-    
     // 显示提示
     uni.showToast({
       title: '定时停止播放',
@@ -171,7 +177,13 @@ const actions = {
   },
   
   // 恢复定时器（从本地存储）
-  restoreTimer({ commit, dispatch }) {
+  restoreTimer({ commit, dispatch, state }) {
+    // 如果定时器已经激活，不重复恢复
+    if (state.isTimerActive) {
+      console.log('定时器已激活，跳过恢复')
+      return
+    }
+    
     const endTime = uni.getStorageSync('sleepTimerEnd')
     const duration = uni.getStorageSync('sleepTimerDuration')
     
@@ -223,8 +235,11 @@ const actions = {
           duration: 2000
         })
       } else {
-        // 定时器已过期，清除存储
-        dispatch('stopSleepTimer')
+        // 定时器已过期，只清除存储，不调用onTimerEnd避免重复触发
+        console.log('定时器已过期，清除存储')
+        commit('CLEAR_TIMER')
+        uni.removeStorageSync('sleepTimerEnd')
+        uni.removeStorageSync('sleepTimerDuration')
       }
     }
   },


### PR DESCRIPTION
Fixes an infinite loop of timer messages on app restart and ensures correct next/previous song behavior in single-loop playback mode.

The timer issue was caused by `restoreTimer` being called redundantly on app launch/show, and `onTimerEnd` repeatedly triggering when an expired timer was restored. For audio playback, in single-loop mode, `onEnded` incorrectly called `playNext` (which returned the current index), causing the same song to replay indefinitely. This PR modifies `onEnded` to handle single-loop by re-setting the `src` and updates `nextIndex`/`previousIndex` getters to always return the actual next/previous song, allowing manual skips in loop mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-142fa52a-68cb-4558-9e2b-88b5d4840d41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-142fa52a-68cb-4558-9e2b-88b5d4840d41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

